### PR TITLE
Add README and set CHANGELOG version to v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## v1.0.0
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -1,25 +1,21 @@
 # Week Planner
 
-A template to get started with Nextcloud app development.
+<img src="img/app.svg" width="100" alt="Week Planner icon">
 
-## Usage
+A Nextcloud app that gives you a weekly overview of your tasks. Plan your week by organising todos across each day, similar to standalone tools like [Tweek](https://tweek.so) or [TeuxDeux](https://teuxdeux.com), but integrated directly into your Nextcloud instance.
 
-- To get started easily use the [Appstore App generator](https://apps.nextcloud.com/developer/apps/generate) to
-  dynamically generate an App based on this repository with all the constants prefilled.
-- Alternatively you can use the "Use this template" button on the top of this page to create a new repository based on
-  this repository. Afterwards adjust all the necessary constants like App ID, namespace, descriptions etc.
+## Features
 
-Once your app is ready follow the [instructions](https://nextcloudappstore.readthedocs.io/en/latest/developer.html) to
-upload it to the Appstore.
+- View your tasks in a clean, week-based layout
+- Create and edit tasks for any day of the week
+- Drag and drop tasks between days to reschedule them
+- Tick off tasks as you complete them
+- Delete tasks you no longer need
 
-## Resources
+### Planned
 
-### Documentation for developers:
+- Recurring tasks
 
-- General documentation and tutorials: https://nextcloud.com/developer
-- Technical documentation: https://docs.nextcloud.com/server/latest/developer_manual
+## Licence
 
-### Help for developers:
-
-- Official community chat: https://cloud.nextcloud.com/call/xs25tz5y
-- Official community forum: https://help.nextcloud.com/c/dev/11
+This project is licenced under the [GNU AGPL v3 or later](LICENSE).


### PR DESCRIPTION
Replace the template README with a proper description of the Week Planner app and its features. Update CHANGELOG to mark the first release as v1.0.0.

https://claude.ai/code/session_01Eq6pBuxjceySEs96YzGU9x