### PR TITLE
Add custom columns feature with persistent storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 
 /vendor/
 /vendor-bin/*/vendor/
+/vendor-bin/*/composer.lock
+/composer.lock
 
 /.php-cs-fixer.cache
 /tests/.phpunit.cache

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,22 @@
+# Development Guidelines
+
+## Commit Messages
+
+All commit messages **must** follow the [Conventional Commits](https://www.conventionalcommits.org/) specification.
+
+Format: `<type>(<optional scope>): <description>`
+
+Types: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `perf`, `test`, `ci`, `build`
+
+Examples:
+- `feat: add custom columns below week grid`
+- `fix: resolve drag-and-drop between columns`
+- `chore: bump version to 1.1.0`
+- `style: align custom columns with weekday grid`
+
+This is enforced by CI via the `block-unconventional-commits` workflow.
+
+## CI Checks
+
+- **npm lint** (`npm run lint`): ESLint for TypeScript/Vue sources
+- **psalm** (`vendor/bin/psalm`): Static analysis for PHP code

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<name>Week Planner</name>
 	<summary>Weekly planner like Tweek</summary>
 	<description>Provides a weekly overview of todos, allowing users to drag and drop between days and tick off tasks as they get done.</description>
-	<version>1.0.0</version>
+	<version>1.1.0</version>
 	<licence>AGPL-3.0-or-later</licence>
 	<author mail="soeren@soeren.codes" homepage="https://www.soeren.codes">Sören Johanson</author>
 	<namespace>WeekPlanner</namespace>

--- a/lib/Controller/CustomColumnsController.php
+++ b/lib/Controller/CustomColumnsController.php
@@ -78,8 +78,8 @@ class CustomColumnsController extends Controller {
 	private function emptyCustomColumns(): array {
 		return [
 			'columns' => [
-				['id' => 'custom_1', 'title' => '', 'tasks' => []],
-				['id' => 'custom_2', 'title' => 'Someday', 'tasks' => []],
+				['id' => 'custom_1', 'title' => 'Someday', 'tasks' => []],
+				['id' => 'custom_2', 'title' => '', 'tasks' => []],
 				['id' => 'custom_3', 'title' => '', 'tasks' => []],
 			],
 		];

--- a/lib/Controller/CustomColumnsController.php
+++ b/lib/Controller/CustomColumnsController.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\WeekPlanner\Controller;
+
+use OCA\WeekPlanner\AppInfo\Application;
+use OCA\WeekPlanner\Db\CustomColumns;
+use OCA\WeekPlanner\Db\CustomColumnsMapper;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\FrontpageRoute;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IRequest;
+use OCP\IUserSession;
+
+/**
+ * @psalm-suppress UnusedClass
+ */
+class CustomColumnsController extends Controller {
+	public function __construct(
+		IRequest $request,
+		private CustomColumnsMapper $mapper,
+		private IUserSession $userSession,
+	) {
+		parent::__construct(Application::APP_ID, $request);
+	}
+
+	#[NoAdminRequired]
+	#[FrontpageRoute(verb: 'GET', url: '/custom-columns')]
+	public function get(): JSONResponse {
+		$user = $this->userSession->getUser();
+		if ($user === null) {
+			return new JSONResponse(['error' => 'Not logged in'], Http::STATUS_UNAUTHORIZED);
+		}
+
+		$entity = $this->mapper->findByUser($user->getUID());
+		if ($entity !== null) {
+			/** @psalm-suppress MixedAssignment */
+			$data = json_decode($entity->getData(), true);
+			if (is_array($data)) {
+				return new JSONResponse($data);
+			}
+		}
+
+		return new JSONResponse($this->emptyCustomColumns());
+	}
+
+	#[NoAdminRequired]
+	#[FrontpageRoute(verb: 'PUT', url: '/custom-columns')]
+	public function put(array $columns = []): JSONResponse {
+		$user = $this->userSession->getUser();
+		if ($user === null) {
+			return new JSONResponse(['error' => 'Not logged in'], Http::STATUS_UNAUTHORIZED);
+		}
+
+		$userId = $user->getUID();
+		$jsonData = json_encode(['columns' => $columns], JSON_UNESCAPED_UNICODE);
+
+		$now = time();
+		$existing = $this->mapper->findByUser($userId);
+		if ($existing !== null) {
+			$existing->setData($jsonData);
+			$existing->setUpdatedAt($now);
+			$this->mapper->update($existing);
+		} else {
+			$entity = new CustomColumns();
+			$entity->setUserId($userId);
+			$entity->setData($jsonData);
+			$entity->setUpdatedAt($now);
+			$this->mapper->insert($entity);
+		}
+
+		return new JSONResponse(['status' => 'ok']);
+	}
+
+	private function emptyCustomColumns(): array {
+		return [
+			'columns' => [
+				['id' => 'custom_1', 'title' => '', 'tasks' => []],
+				['id' => 'custom_2', 'title' => 'Someday', 'tasks' => []],
+				['id' => 'custom_3', 'title' => '', 'tasks' => []],
+			],
+		];
+	}
+}

--- a/lib/Db/CustomColumns.php
+++ b/lib/Db/CustomColumns.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\WeekPlanner\Db;
+
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * @method string getUserId()
+ * @method void setUserId(string $userId)
+ * @method string getData()
+ * @method void setData(string $data)
+ * @method int getUpdatedAt()
+ * @method void setUpdatedAt(int $updatedAt)
+ * @psalm-suppress PropertyNotSetInConstructor
+ */
+class CustomColumns extends Entity {
+	/** @psalm-suppress PossiblyUnusedProperty */
+	protected string $userId = '';
+	/** @psalm-suppress PossiblyUnusedProperty */
+	protected string $data = '{}';
+	/** @psalm-suppress PossiblyUnusedProperty */
+	protected int $updatedAt = 0;
+
+	public function __construct() {
+		$this->addType('userId', 'string');
+		$this->addType('data', 'string');
+		$this->addType('updatedAt', 'integer');
+	}
+}

--- a/lib/Db/CustomColumnsMapper.php
+++ b/lib/Db/CustomColumnsMapper.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\WeekPlanner\Db;
+
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\QBMapper;
+use OCP\IDBConnection;
+
+/**
+ * @template-extends QBMapper<CustomColumns>
+ */
+class CustomColumnsMapper extends QBMapper {
+	/**
+	 * @psalm-suppress PossiblyUnusedMethod
+	 */
+	public function __construct(IDBConnection $db) {
+		parent::__construct($db, 'weekplanner_custom_columns', CustomColumns::class);
+	}
+
+	public function findByUser(string $userId): ?CustomColumns {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('user_id', $qb->createNamedParameter($userId)));
+
+		try {
+			return $this->findEntity($qb);
+		} catch (DoesNotExistException) {
+			return null;
+		}
+	}
+}

--- a/lib/Db/WeekMapper.php
+++ b/lib/Db/WeekMapper.php
@@ -29,6 +29,7 @@ class WeekMapper extends QBMapper {
 			->andWhere($qb->expr()->eq('week', $qb->createNamedParameter($week, IQueryBuilder::PARAM_INT)));
 
 		$result = $qb->executeQuery();
+		/** @var array{updated_at: int}|false $row */
 		$row = $result->fetch();
 		$result->closeCursor();
 

--- a/lib/Db/WeekMapper.php
+++ b/lib/Db/WeekMapper.php
@@ -33,7 +33,7 @@ class WeekMapper extends QBMapper {
 		$row = $result->fetch();
 		$result->closeCursor();
 
-		return $row !== false ? (int)$row['updated_at'] : 0;
+		return $row !== false ? $row['updated_at'] : 0;
 	}
 
 	public function findByUserAndWeek(string $userId, int $year, int $week): ?Week {

--- a/lib/Migration/Version1001Date20260307120000.php
+++ b/lib/Migration/Version1001Date20260307120000.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\WeekPlanner\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * @psalm-suppress UnusedClass
+ * @psalm-suppress UndefinedDocblockClass
+ */
+class Version1001Date20260307120000 extends SimpleMigrationStep {
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		$schema = $schemaClosure();
+
+		if (!$schema->hasTable('weekplanner_custom_columns')) {
+			$table = $schema->createTable('weekplanner_custom_columns');
+			$table->addColumn('id', Types::BIGINT, [
+				'autoincrement' => true,
+				'notnull' => true,
+				'length' => 8,
+			]);
+			$table->addColumn('user_id', Types::STRING, [
+				'notnull' => true,
+				'length' => 64,
+			]);
+			$table->addColumn('data', Types::TEXT, [
+				'notnull' => true,
+				'default' => '{}',
+			]);
+			$table->addColumn('updated_at', Types::BIGINT, [
+				'notnull' => true,
+				'default' => 0,
+			]);
+			$table->setPrimaryKey(['id']);
+			$table->addUniqueIndex(['user_id'], 'weekplanner_custom_cols_user');
+		}
+
+		return $schema;
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "weekplanner",
-  "version": "1.2.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "weekplanner",
-      "version": "1.2.0",
+      "version": "1.0.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@nextcloud/axios": "^2.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weekplanner",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -1055,7 +1055,7 @@ onUnmounted(() => {
 /* Custom columns */
 .custom-columns-grid {
 	display: grid;
-	grid-template-columns: repeat(3, 1fr);
+	grid-template-columns: repeat(5, 1fr) 0.8fr;
 	gap: 1px;
 	height: 30vh;
 	min-height: 200px;
@@ -1065,6 +1065,10 @@ onUnmounted(() => {
 	border-top: none;
 	border-radius: 0 0 8px 8px;
 	overflow: hidden;
+}
+
+.custom-columns-grid .custom-column {
+	grid-column: span 2;
 }
 
 .custom-column-header {
@@ -1249,7 +1253,8 @@ onUnmounted(() => {
 		min-height: unset;
 	}
 
-	.custom-column {
+	.custom-columns-grid .custom-column {
+		grid-column: span 1;
 		min-height: 80px;
 	}
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -673,71 +673,41 @@ onUnmounted(() => {
 						</div>
 					</div>
 
-					<div
-						v-for="day in WEEKEND_KEYS"
-						:key="day"
-						class="day-column bottom-column">
-						<div class="day-header" :class="{ 'is-today': isToday(day) }">
-							<span class="day-name">{{ DAY_LABELS[day] }}</span>
-							<span class="day-date">{{ formatDate(day) }}</span>
-						</div>
-						<div class="day-tasks">
-							<draggable
-								v-model="weekData.days[day]"
-								group="weekGroup"
-								item-key="id"
-								class="task-list"
-								@change="onDragChange">
-								<template #item="{ element }: { element: Task }">
-									<div class="task-item" :class="{ done: element.done }">
-										<span class="task-title" @click="openEdit(day, element)">
-											{{ element.title }}
-										</span>
-										<svg v-if="element.notes"
-											class="task-notes-icon"
-											xmlns="http://www.w3.org/2000/svg"
-											viewBox="0 0 24 24"
-											width="20"
-											height="20"
-											fill="currentColor">
-											<path d="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M14,18H6V16H14V18M18,14H6V12H18V14M13,9V3.5L18.5,9H13Z" />
-										</svg>
-										<button
-											class="task-check"
-											:class="{ checked: element.done }"
-											@click.stop="toggleDone(day, element.id)">
-											<svg v-if="element.done"
+					<div class="weekend-column bottom-column">
+						<div
+							v-for="day in WEEKEND_KEYS"
+							:key="day"
+							class="weekend-half">
+							<div class="day-header" :class="{ 'is-today': isToday(day) }">
+								<span class="day-name">{{ DAY_LABELS[day] }}</span>
+								<span class="day-date">{{ formatDate(day) }}</span>
+							</div>
+							<div class="day-tasks">
+								<draggable
+									v-model="weekData.days[day]"
+									group="weekGroup"
+									item-key="id"
+									class="task-list"
+									@change="onDragChange">
+									<template #item="{ element }: { element: Task }">
+										<div class="task-item" :class="{ done: element.done }">
+											<span class="task-title" @click="openEdit(day, element)">
+												{{ element.title }}
+											</span>
+											<svg v-if="element.notes"
+												class="task-notes-icon"
 												xmlns="http://www.w3.org/2000/svg"
 												viewBox="0 0 24 24"
 												width="20"
-												height="20">
-												<circle cx="12"
-													cy="12"
-													r="10"
-													fill="var(--color-primary-element)"
-													stroke="var(--color-primary-element)"
-													stroke-width="1.5" />
-												<path d="M8 12l2.5 2.5L16 9"
-													fill="none"
-													stroke="white"
-													stroke-width="2"
-													stroke-linecap="round"
-													stroke-linejoin="round" />
+												height="20"
+												fill="currentColor">
+												<path d="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M14,18H6V16H14V18M18,14H6V12H18V14M13,9V3.5L18.5,9H13Z" />
 											</svg>
-											<template v-else>
-												<svg class="check-idle"
-													xmlns="http://www.w3.org/2000/svg"
-													viewBox="0 0 24 24"
-													width="20"
-													height="20">
-													<circle cx="12"
-														cy="12"
-														r="10"
-														fill="none"
-														stroke="currentColor"
-														stroke-width="1.5" />
-												</svg>
-												<svg class="check-hover"
+											<button
+												class="task-check"
+												:class="{ checked: element.done }"
+												@click.stop="toggleDone(day, element.id)">
+												<svg v-if="element.done"
 													xmlns="http://www.w3.org/2000/svg"
 													viewBox="0 0 24 24"
 													width="20"
@@ -755,20 +725,52 @@ onUnmounted(() => {
 														stroke-linecap="round"
 														stroke-linejoin="round" />
 												</svg>
-											</template>
-										</button>
-									</div>
-								</template>
-							</draggable>
-							<div class="task-add">
-								<input
-									v-model="newTasks[day]"
-									class="task-input"
-									placeholder="Add task…"
-									@keydown.enter="addTask(day)">
-								<button class="task-add-btn" @click="addTask(day)">
-									+
-								</button>
+												<template v-else>
+													<svg class="check-idle"
+														xmlns="http://www.w3.org/2000/svg"
+														viewBox="0 0 24 24"
+														width="20"
+														height="20">
+														<circle cx="12"
+															cy="12"
+															r="10"
+															fill="none"
+															stroke="currentColor"
+															stroke-width="1.5" />
+													</svg>
+													<svg class="check-hover"
+														xmlns="http://www.w3.org/2000/svg"
+														viewBox="0 0 24 24"
+														width="20"
+														height="20">
+														<circle cx="12"
+															cy="12"
+															r="10"
+															fill="var(--color-primary-element)"
+															stroke="var(--color-primary-element)"
+															stroke-width="1.5" />
+														<path d="M8 12l2.5 2.5L16 9"
+															fill="none"
+															stroke="white"
+															stroke-width="2"
+															stroke-linecap="round"
+															stroke-linejoin="round" />
+													</svg>
+												</template>
+											</button>
+										</div>
+									</template>
+								</draggable>
+								<div class="task-add">
+									<input
+										v-model="newTasks[day]"
+										class="task-input"
+										placeholder="Add task…"
+										@keydown.enter="addTask(day)">
+									<button class="task-add-btn" @click="addTask(day)">
+										+
+									</button>
+								</div>
 							</div>
 						</div>
 					</div>
@@ -874,6 +876,21 @@ onUnmounted(() => {
 
 .bottom-column {
 	grid-row: 2;
+}
+
+.weekend-column {
+	display: flex;
+	flex-direction: column;
+	gap: 1px;
+	background-color: var(--color-border);
+}
+
+.weekend-half {
+	display: flex;
+	flex-direction: column;
+	flex: 1;
+	background-color: var(--color-main-background);
+	min-height: 0;
 }
 
 .day-header {
@@ -1223,7 +1240,9 @@ onUnmounted(() => {
 		grid-row: auto;
 	}
 
-	.day-column {
+	.day-column,
+	.weekend-column,
+	.weekend-half {
 		min-height: unset;
 	}
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -20,6 +20,12 @@ interface WeekData {
 	days: Record<DayKey, Task[]>
 }
 
+interface CustomColumn {
+	id: string
+	title: string
+	tasks: Task[]
+}
+
 const WEEKDAY_KEYS: DayKey[] = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday']
 const WEEKEND_KEYS: DayKey[] = ['saturday', 'sunday']
 const DAY_LABELS: Record<DayKey, string> = {
@@ -46,8 +52,20 @@ const newTasks = ref<Record<DayKey, string>>({
 	sunday: '',
 })
 
+// Custom columns state (persists across weeks)
+const customColumns = ref<CustomColumn[]>([
+	{ id: 'custom_1', title: '', tasks: [] },
+	{ id: 'custom_2', title: 'Someday', tasks: [] },
+	{ id: 'custom_3', title: '', tasks: [] },
+])
+const newCustomTasks = ref<Record<string, string>>({
+	custom_1: '',
+	custom_2: '',
+	custom_3: '',
+})
+
 // Edit dialog state
-const editingTask = ref<{ day: DayKey; taskId: string } | null>(null)
+const editingTask = ref<{ day: DayKey | string; taskId: string } | null>(null)
 const editTitle = ref('')
 const editNotes = ref('')
 const editTitleInput = ref<HTMLInputElement | null>(null)
@@ -184,6 +202,88 @@ function debouncedSave() {
 	}, 300)
 }
 
+// Custom columns persistence (separate from weekly data)
+async function loadCustomColumns() {
+	try {
+		const url = generateUrl('/apps/weekplanner/custom-columns')
+		const response = await axios.get(url)
+		const data = response.data as { columns?: CustomColumn[] }
+		if (data.columns && Array.isArray(data.columns)) {
+			customColumns.value = data.columns.map((col) => ({
+				...col,
+				tasks: (col.tasks || []).map((t) => ({ ...t, notes: t.notes || '' })),
+			}))
+			// Sync newCustomTasks keys
+			const newObj: Record<string, string> = {}
+			for (const col of customColumns.value) {
+				newObj[col.id] = newCustomTasks.value[col.id] || ''
+			}
+			newCustomTasks.value = newObj
+		}
+	} catch {
+		// Keep defaults
+	}
+}
+
+let customSaveTimeout: ReturnType<typeof setTimeout> | null = null
+
+function debouncedSaveCustomColumns() {
+	if (customSaveTimeout) clearTimeout(customSaveTimeout)
+	customSaveTimeout = setTimeout(async () => {
+		customSaveTimeout = null
+		try {
+			const url = generateUrl('/apps/weekplanner/custom-columns')
+			await axios.put(url, { columns: customColumns.value })
+		} catch {
+			// Save failed silently
+		}
+	}, 300)
+}
+
+function addCustomTask(columnId: string) {
+	const title = newCustomTasks.value[columnId]?.trim()
+	if (!title) return
+	const col = customColumns.value.find((c) => c.id === columnId)
+	if (!col) return
+	col.tasks.push({
+		id: crypto.randomUUID(),
+		title,
+		done: false,
+		notes: '',
+	})
+	newCustomTasks.value[columnId] = ''
+	debouncedSaveCustomColumns()
+}
+
+function toggleCustomDone(columnId: string, taskId: string) {
+	const col = customColumns.value.find((c) => c.id === columnId)
+	if (!col) return
+	const task = col.tasks.find((t) => t.id === taskId)
+	if (task) {
+		task.done = !task.done
+		debouncedSaveCustomColumns()
+	}
+}
+
+function deleteCustomTask(columnId: string, taskId: string) {
+	const col = customColumns.value.find((c) => c.id === columnId)
+	if (!col) return
+	col.tasks = col.tasks.filter((t) => t.id !== taskId)
+	debouncedSaveCustomColumns()
+}
+
+function updateColumnTitle(columnId: string, title: string) {
+	const col = customColumns.value.find((c) => c.id === columnId)
+	if (col) {
+		col.title = title
+		debouncedSaveCustomColumns()
+	}
+}
+
+function onCustomDragChange() {
+	debouncedSaveCustomColumns()
+}
+
 function addTask(day: DayKey) {
 	const title = newTasks.value[day].trim()
 	if (!title) return
@@ -210,7 +310,11 @@ function deleteTask(day: DayKey, taskId: string) {
 	debouncedSave()
 }
 
-function openEdit(day: DayKey, task: Task) {
+function isCustomColumn(key: string): boolean {
+	return key.startsWith('custom_')
+}
+
+function openEdit(day: DayKey | string, task: Task) {
 	editingTask.value = { day, taskId: task.id }
 	editTitle.value = task.title
 	editNotes.value = task.notes || ''
@@ -222,11 +326,23 @@ function openEdit(day: DayKey, task: Task) {
 function saveEdit() {
 	if (!editingTask.value) return
 	const { day, taskId } = editingTask.value
-	const task = weekData.value.days[day].find((t) => t.id === taskId)
-	if (task) {
-		task.title = editTitle.value.trim() || task.title
-		task.notes = editNotes.value
-		debouncedSave()
+	if (isCustomColumn(day)) {
+		const col = customColumns.value.find((c) => c.id === day)
+		if (col) {
+			const task = col.tasks.find((t) => t.id === taskId)
+			if (task) {
+				task.title = editTitle.value.trim() || task.title
+				task.notes = editNotes.value
+				debouncedSaveCustomColumns()
+			}
+		}
+	} else {
+		const task = weekData.value.days[day as DayKey].find((t) => t.id === taskId)
+		if (task) {
+			task.title = editTitle.value.trim() || task.title
+			task.notes = editNotes.value
+			debouncedSave()
+		}
 	}
 	editingTask.value = null
 }
@@ -234,12 +350,23 @@ function saveEdit() {
 function deleteEditingTask() {
 	if (!editingTask.value) return
 	const { day, taskId } = editingTask.value
-	deleteTask(day, taskId)
+	if (isCustomColumn(day)) {
+		deleteCustomTask(day, taskId)
+	} else {
+		deleteTask(day as DayKey, taskId)
+	}
 	editingTask.value = null
 }
 
 function onDragChange() {
 	debouncedSave()
+	// Also save custom columns in case a task was dragged out of a custom column
+	debouncedSaveCustomColumns()
+}
+
+function onCustomOrWeekDragChange() {
+	debouncedSave()
+	debouncedSaveCustomColumns()
 }
 
 function prevWeek() {
@@ -308,11 +435,13 @@ onMounted(() => {
 	const { year, week } = getISOWeek(new Date())
 	currentYear.value = year
 	currentWeek.value = week
+	loadCustomColumns()
 })
 
 onUnmounted(() => {
 	stopLongPoll()
 	if (saveTimeout) clearTimeout(saveTimeout)
+	if (customSaveTimeout) clearTimeout(customSaveTimeout)
 })
 </script>
 
@@ -541,6 +670,112 @@ onUnmounted(() => {
 					</div>
 				</div>
 
+				<div class="custom-columns-grid">
+					<div
+						v-for="col in customColumns"
+						:key="col.id"
+						class="custom-column">
+						<div class="day-header custom-column-header">
+							<input
+								class="custom-column-title"
+								:value="col.title"
+								placeholder="Column title…"
+								@input="updateColumnTitle(col.id, ($event.target as HTMLInputElement).value)"
+								@keydown.enter="($event.target as HTMLInputElement).blur()">
+						</div>
+						<div class="day-tasks">
+							<draggable
+								v-model="col.tasks"
+								group="weekGroup"
+								item-key="id"
+								class="task-list"
+								@change="onCustomOrWeekDragChange">
+								<template #item="{ element }: { element: Task }">
+									<div class="task-item" :class="{ done: element.done }">
+										<span class="task-title" @click="openEdit(col.id, element)">
+											{{ element.title }}
+										</span>
+										<svg v-if="element.notes"
+											class="task-notes-icon"
+											xmlns="http://www.w3.org/2000/svg"
+											viewBox="0 0 24 24"
+											width="20"
+											height="20"
+											fill="currentColor">
+											<path d="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M14,18H6V16H14V18M18,14H6V12H18V14M13,9V3.5L18.5,9H13Z" />
+										</svg>
+										<button
+											class="task-check"
+											:class="{ checked: element.done }"
+											@click.stop="toggleCustomDone(col.id, element.id)">
+											<svg v-if="element.done"
+												xmlns="http://www.w3.org/2000/svg"
+												viewBox="0 0 24 24"
+												width="20"
+												height="20">
+												<circle cx="12"
+													cy="12"
+													r="10"
+													fill="var(--color-primary-element)"
+													stroke="var(--color-primary-element)"
+													stroke-width="1.5" />
+												<path d="M8 12l2.5 2.5L16 9"
+													fill="none"
+													stroke="white"
+													stroke-width="2"
+													stroke-linecap="round"
+													stroke-linejoin="round" />
+											</svg>
+											<template v-else>
+												<svg class="check-idle"
+													xmlns="http://www.w3.org/2000/svg"
+													viewBox="0 0 24 24"
+													width="20"
+													height="20">
+													<circle cx="12"
+														cy="12"
+														r="10"
+														fill="none"
+														stroke="currentColor"
+														stroke-width="1.5" />
+												</svg>
+												<svg class="check-hover"
+													xmlns="http://www.w3.org/2000/svg"
+													viewBox="0 0 24 24"
+													width="20"
+													height="20">
+													<circle cx="12"
+														cy="12"
+														r="10"
+														fill="var(--color-primary-element)"
+														stroke="var(--color-primary-element)"
+														stroke-width="1.5" />
+													<path d="M8 12l2.5 2.5L16 9"
+														fill="none"
+														stroke="white"
+														stroke-width="2"
+														stroke-linecap="round"
+														stroke-linejoin="round" />
+												</svg>
+											</template>
+										</button>
+									</div>
+								</template>
+							</draggable>
+							<div class="task-add">
+								<input
+									v-model="newCustomTasks[col.id]"
+									class="task-input"
+									placeholder="Add task…"
+									@keydown.enter="addCustomTask(col.id)">
+								<button class="task-add-btn" @click="addCustomTask(col.id)">
+									+
+								</button>
+							</div>
+						</div>
+					</div>
+				</div>
+
 				<!-- Edit Task Dialog -->
 				<div v-if="editingTask" class="edit-overlay" @click.self="saveEdit">
 					<div class="edit-dialog" @keydown.escape="saveEdit">
@@ -617,13 +852,13 @@ onUnmounted(() => {
 
 .week-grid {
 	display: grid;
-	grid-template-columns: repeat(5, 1fr) 0.8fr;
+	grid-template-columns: repeat(5, 1fr) 0.6fr;
 	gap: 1px;
 	flex: 1;
 	min-height: 0;
 	background-color: var(--color-border);
 	border: 1px solid var(--color-border);
-	border-radius: 8px;
+	border-radius: 8px 8px 0 0;
 	overflow: hidden;
 }
 
@@ -817,6 +1052,52 @@ onUnmounted(() => {
 	color: var(--color-primary-element-hover);
 }
 
+/* Custom columns */
+.custom-columns-grid {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	gap: 1px;
+	min-height: 120px;
+	background-color: var(--color-border);
+	border: 1px solid var(--color-border);
+	border-top: none;
+	border-radius: 0 0 8px 8px;
+	overflow: hidden;
+}
+
+.custom-column {
+	display: flex;
+	flex-direction: column;
+	background-color: var(--color-main-background);
+	min-height: 0;
+}
+
+.custom-column-header {
+	display: flex;
+	align-items: center;
+}
+
+.custom-column-title {
+	width: 100%;
+	border: none;
+	background: transparent;
+	font-size: 14px;
+	font-weight: 600;
+	color: var(--color-text-maxcontrast);
+	outline: none;
+	padding: 0;
+	font-family: inherit;
+}
+
+.custom-column-title::placeholder {
+	color: var(--color-text-maxcontrast);
+	opacity: 0.6;
+}
+
+.custom-column-title:focus {
+	color: var(--color-main-text);
+}
+
 /* Edit dialog */
 .edit-overlay {
 	position: fixed;
@@ -961,11 +1242,21 @@ onUnmounted(() => {
 	.week-grid {
 		grid-template-columns: 1fr;
 		overflow: visible;
+		border-radius: 8px;
+	}
+
+	.custom-columns-grid {
+		grid-template-columns: 1fr;
+		border-top: 1px solid var(--color-border);
+		border-radius: 8px;
+		margin-top: 8px;
+		min-height: unset;
 	}
 
 	.day-column,
 	.weekend-column,
-	.weekend-half {
+	.weekend-half,
+	.custom-column {
 		min-height: unset;
 	}
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -54,8 +54,8 @@ const newTasks = ref<Record<DayKey, string>>({
 
 // Custom columns state (persists across weeks)
 const customColumns = ref<CustomColumn[]>([
-	{ id: 'custom_1', title: '', tasks: [] },
-	{ id: 'custom_2', title: 'Someday', tasks: [] },
+	{ id: 'custom_1', title: 'Someday', tasks: [] },
+	{ id: 'custom_2', title: '', tasks: [] },
 	{ id: 'custom_3', title: '', tasks: [] },
 ])
 const newCustomTasks = ref<Record<string, string>>({
@@ -467,10 +467,11 @@ onUnmounted(() => {
 				</div>
 
 				<div class="week-grid">
+					<!-- Row 1: Weekdays (Mon–Fri) -->
 					<div
 						v-for="day in WEEKDAY_KEYS"
 						:key="day"
-						class="day-column">
+						class="day-column weekday-column">
 						<div class="day-header" :class="{ 'is-today': isToday(day) }">
 							<span class="day-name">{{ DAY_LABELS[day] }}</span>
 							<span class="day-date">{{ formatDate(day) }}</span>
@@ -567,114 +568,11 @@ onUnmounted(() => {
 						</div>
 					</div>
 
-					<div class="weekend-column">
-						<div
-							v-for="day in WEEKEND_KEYS"
-							:key="day"
-							class="weekend-half">
-							<div class="day-header" :class="{ 'is-today': isToday(day) }">
-								<span class="day-name">{{ DAY_LABELS[day] }}</span>
-								<span class="day-date">{{ formatDate(day) }}</span>
-							</div>
-							<div class="day-tasks">
-								<draggable
-									v-model="weekData.days[day]"
-									group="weekGroup"
-									item-key="id"
-									class="task-list"
-									@change="onDragChange">
-									<template #item="{ element }: { element: Task }">
-										<div class="task-item" :class="{ done: element.done }">
-											<span class="task-title" @click="openEdit(day, element)">
-												{{ element.title }}
-											</span>
-											<svg v-if="element.notes"
-												class="task-notes-icon"
-												xmlns="http://www.w3.org/2000/svg"
-												viewBox="0 0 24 24"
-												width="20"
-												height="20"
-												fill="currentColor">
-												<path d="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M14,18H6V16H14V18M18,14H6V12H18V14M13,9V3.5L18.5,9H13Z" />
-											</svg>
-											<button
-												class="task-check"
-												:class="{ checked: element.done }"
-												@click.stop="toggleDone(day, element.id)">
-												<svg v-if="element.done"
-													xmlns="http://www.w3.org/2000/svg"
-													viewBox="0 0 24 24"
-													width="20"
-													height="20">
-													<circle cx="12"
-														cy="12"
-														r="10"
-														fill="var(--color-primary-element)"
-														stroke="var(--color-primary-element)"
-														stroke-width="1.5" />
-													<path d="M8 12l2.5 2.5L16 9"
-														fill="none"
-														stroke="white"
-														stroke-width="2"
-														stroke-linecap="round"
-														stroke-linejoin="round" />
-												</svg>
-												<template v-else>
-													<svg class="check-idle"
-														xmlns="http://www.w3.org/2000/svg"
-														viewBox="0 0 24 24"
-														width="20"
-														height="20">
-														<circle cx="12"
-															cy="12"
-															r="10"
-															fill="none"
-															stroke="currentColor"
-															stroke-width="1.5" />
-													</svg>
-													<svg class="check-hover"
-														xmlns="http://www.w3.org/2000/svg"
-														viewBox="0 0 24 24"
-														width="20"
-														height="20">
-														<circle cx="12"
-															cy="12"
-															r="10"
-															fill="var(--color-primary-element)"
-															stroke="var(--color-primary-element)"
-															stroke-width="1.5" />
-														<path d="M8 12l2.5 2.5L16 9"
-															fill="none"
-															stroke="white"
-															stroke-width="2"
-															stroke-linecap="round"
-															stroke-linejoin="round" />
-													</svg>
-												</template>
-											</button>
-										</div>
-									</template>
-								</draggable>
-								<div class="task-add">
-									<input
-										v-model="newTasks[day]"
-										class="task-input"
-										placeholder="Add task…"
-										@keydown.enter="addTask(day)">
-									<button class="task-add-btn" @click="addTask(day)">
-										+
-									</button>
-								</div>
-							</div>
-						</div>
-					</div>
-				</div>
-
-				<div class="custom-columns-grid">
+					<!-- Row 2: Custom columns + Weekend (Sat & Sun) -->
 					<div
 						v-for="col in customColumns"
 						:key="col.id"
-						class="custom-column">
+						class="day-column bottom-column custom-column">
 						<div class="day-header custom-column-header">
 							<input
 								class="custom-column-title"
@@ -774,6 +672,106 @@ onUnmounted(() => {
 							</div>
 						</div>
 					</div>
+
+					<div
+						v-for="day in WEEKEND_KEYS"
+						:key="day"
+						class="day-column bottom-column">
+						<div class="day-header" :class="{ 'is-today': isToday(day) }">
+							<span class="day-name">{{ DAY_LABELS[day] }}</span>
+							<span class="day-date">{{ formatDate(day) }}</span>
+						</div>
+						<div class="day-tasks">
+							<draggable
+								v-model="weekData.days[day]"
+								group="weekGroup"
+								item-key="id"
+								class="task-list"
+								@change="onDragChange">
+								<template #item="{ element }: { element: Task }">
+									<div class="task-item" :class="{ done: element.done }">
+										<span class="task-title" @click="openEdit(day, element)">
+											{{ element.title }}
+										</span>
+										<svg v-if="element.notes"
+											class="task-notes-icon"
+											xmlns="http://www.w3.org/2000/svg"
+											viewBox="0 0 24 24"
+											width="20"
+											height="20"
+											fill="currentColor">
+											<path d="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M14,18H6V16H14V18M18,14H6V12H18V14M13,9V3.5L18.5,9H13Z" />
+										</svg>
+										<button
+											class="task-check"
+											:class="{ checked: element.done }"
+											@click.stop="toggleDone(day, element.id)">
+											<svg v-if="element.done"
+												xmlns="http://www.w3.org/2000/svg"
+												viewBox="0 0 24 24"
+												width="20"
+												height="20">
+												<circle cx="12"
+													cy="12"
+													r="10"
+													fill="var(--color-primary-element)"
+													stroke="var(--color-primary-element)"
+													stroke-width="1.5" />
+												<path d="M8 12l2.5 2.5L16 9"
+													fill="none"
+													stroke="white"
+													stroke-width="2"
+													stroke-linecap="round"
+													stroke-linejoin="round" />
+											</svg>
+											<template v-else>
+												<svg class="check-idle"
+													xmlns="http://www.w3.org/2000/svg"
+													viewBox="0 0 24 24"
+													width="20"
+													height="20">
+													<circle cx="12"
+														cy="12"
+														r="10"
+														fill="none"
+														stroke="currentColor"
+														stroke-width="1.5" />
+												</svg>
+												<svg class="check-hover"
+													xmlns="http://www.w3.org/2000/svg"
+													viewBox="0 0 24 24"
+													width="20"
+													height="20">
+													<circle cx="12"
+														cy="12"
+														r="10"
+														fill="var(--color-primary-element)"
+														stroke="var(--color-primary-element)"
+														stroke-width="1.5" />
+													<path d="M8 12l2.5 2.5L16 9"
+														fill="none"
+														stroke="white"
+														stroke-width="2"
+														stroke-linecap="round"
+														stroke-linejoin="round" />
+												</svg>
+											</template>
+										</button>
+									</div>
+								</template>
+							</draggable>
+							<div class="task-add">
+								<input
+									v-model="newTasks[day]"
+									class="task-input"
+									placeholder="Add task…"
+									@keydown.enter="addTask(day)">
+								<button class="task-add-btn" @click="addTask(day)">
+									+
+								</button>
+							</div>
+						</div>
+					</div>
 				</div>
 
 				<!-- Edit Task Dialog -->
@@ -852,13 +850,14 @@ onUnmounted(() => {
 
 .week-grid {
 	display: grid;
-	grid-template-columns: repeat(5, 1fr) 0.6fr;
+	grid-template-columns: repeat(5, 1fr);
+	grid-template-rows: 3fr 1fr;
 	gap: 1px;
 	flex: 1;
 	min-height: 0;
 	background-color: var(--color-border);
 	border: 1px solid var(--color-border);
-	border-radius: 8px 8px 0 0;
+	border-radius: 8px;
 	overflow: hidden;
 }
 
@@ -869,19 +868,12 @@ onUnmounted(() => {
 	min-height: 0;
 }
 
-.weekend-column {
-	display: flex;
-	flex-direction: column;
-	gap: 1px;
-	background-color: var(--color-border);
+.weekday-column {
+	grid-row: 1;
 }
 
-.weekend-half {
-	display: flex;
-	flex-direction: column;
-	flex: 1;
-	background-color: var(--color-main-background);
-	min-height: 0;
+.bottom-column {
+	grid-row: 2;
 }
 
 .day-header {
@@ -1053,25 +1045,6 @@ onUnmounted(() => {
 }
 
 /* Custom columns */
-.custom-columns-grid {
-	display: grid;
-	grid-template-columns: repeat(3, 1fr);
-	gap: 1px;
-	min-height: 120px;
-	background-color: var(--color-border);
-	border: 1px solid var(--color-border);
-	border-top: none;
-	border-radius: 0 0 8px 8px;
-	overflow: hidden;
-}
-
-.custom-column {
-	display: flex;
-	flex-direction: column;
-	background-color: var(--color-main-background);
-	min-height: 0;
-}
-
 .custom-column-header {
 	display: flex;
 	align-items: center;
@@ -1241,22 +1214,16 @@ onUnmounted(() => {
 
 	.week-grid {
 		grid-template-columns: 1fr;
+		grid-template-rows: none;
 		overflow: visible;
-		border-radius: 8px;
 	}
 
-	.custom-columns-grid {
-		grid-template-columns: 1fr;
-		border-top: 1px solid var(--color-border);
-		border-radius: 8px;
-		margin-top: 8px;
-		min-height: unset;
+	.weekday-column,
+	.bottom-column {
+		grid-row: auto;
 	}
 
-	.day-column,
-	.weekend-column,
-	.weekend-half,
-	.custom-column {
+	.day-column {
 		min-height: unset;
 	}
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -280,10 +280,6 @@ function updateColumnTitle(columnId: string, title: string) {
 	}
 }
 
-function onCustomDragChange() {
-	debouncedSaveCustomColumns()
-}
-
 function addTask(day: DayKey) {
 	const title = newTasks.value[day].trim()
 	if (!title) return

--- a/src/App.vue
+++ b/src/App.vue
@@ -467,11 +467,10 @@ onUnmounted(() => {
 				</div>
 
 				<div class="week-grid">
-					<!-- Row 1: Weekdays (Mon–Fri) -->
 					<div
 						v-for="day in WEEKDAY_KEYS"
 						:key="day"
-						class="day-column weekday-column">
+						class="day-column">
 						<div class="day-header" :class="{ 'is-today': isToday(day) }">
 							<span class="day-name">{{ DAY_LABELS[day] }}</span>
 							<span class="day-date">{{ formatDate(day) }}</span>
@@ -568,112 +567,7 @@ onUnmounted(() => {
 						</div>
 					</div>
 
-					<!-- Row 2: Custom columns + Weekend (Sat & Sun) -->
-					<div
-						v-for="col in customColumns"
-						:key="col.id"
-						class="day-column bottom-column custom-column">
-						<div class="day-header custom-column-header">
-							<input
-								class="custom-column-title"
-								:value="col.title"
-								placeholder="Column title…"
-								@input="updateColumnTitle(col.id, ($event.target as HTMLInputElement).value)"
-								@keydown.enter="($event.target as HTMLInputElement).blur()">
-						</div>
-						<div class="day-tasks">
-							<draggable
-								v-model="col.tasks"
-								group="weekGroup"
-								item-key="id"
-								class="task-list"
-								@change="onCustomOrWeekDragChange">
-								<template #item="{ element }: { element: Task }">
-									<div class="task-item" :class="{ done: element.done }">
-										<span class="task-title" @click="openEdit(col.id, element)">
-											{{ element.title }}
-										</span>
-										<svg v-if="element.notes"
-											class="task-notes-icon"
-											xmlns="http://www.w3.org/2000/svg"
-											viewBox="0 0 24 24"
-											width="20"
-											height="20"
-											fill="currentColor">
-											<path d="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M14,18H6V16H14V18M18,14H6V12H18V14M13,9V3.5L18.5,9H13Z" />
-										</svg>
-										<button
-											class="task-check"
-											:class="{ checked: element.done }"
-											@click.stop="toggleCustomDone(col.id, element.id)">
-											<svg v-if="element.done"
-												xmlns="http://www.w3.org/2000/svg"
-												viewBox="0 0 24 24"
-												width="20"
-												height="20">
-												<circle cx="12"
-													cy="12"
-													r="10"
-													fill="var(--color-primary-element)"
-													stroke="var(--color-primary-element)"
-													stroke-width="1.5" />
-												<path d="M8 12l2.5 2.5L16 9"
-													fill="none"
-													stroke="white"
-													stroke-width="2"
-													stroke-linecap="round"
-													stroke-linejoin="round" />
-											</svg>
-											<template v-else>
-												<svg class="check-idle"
-													xmlns="http://www.w3.org/2000/svg"
-													viewBox="0 0 24 24"
-													width="20"
-													height="20">
-													<circle cx="12"
-														cy="12"
-														r="10"
-														fill="none"
-														stroke="currentColor"
-														stroke-width="1.5" />
-												</svg>
-												<svg class="check-hover"
-													xmlns="http://www.w3.org/2000/svg"
-													viewBox="0 0 24 24"
-													width="20"
-													height="20">
-													<circle cx="12"
-														cy="12"
-														r="10"
-														fill="var(--color-primary-element)"
-														stroke="var(--color-primary-element)"
-														stroke-width="1.5" />
-													<path d="M8 12l2.5 2.5L16 9"
-														fill="none"
-														stroke="white"
-														stroke-width="2"
-														stroke-linecap="round"
-														stroke-linejoin="round" />
-												</svg>
-											</template>
-										</button>
-									</div>
-								</template>
-							</draggable>
-							<div class="task-add">
-								<input
-									v-model="newCustomTasks[col.id]"
-									class="task-input"
-									placeholder="Add task…"
-									@keydown.enter="addCustomTask(col.id)">
-								<button class="task-add-btn" @click="addCustomTask(col.id)">
-									+
-								</button>
-							</div>
-						</div>
-					</div>
-
-					<div class="weekend-column bottom-column">
+					<div class="weekend-column">
 						<div
 							v-for="day in WEEKEND_KEYS"
 							:key="day"
@@ -776,6 +670,112 @@ onUnmounted(() => {
 					</div>
 				</div>
 
+				<div class="custom-columns-grid">
+					<div
+						v-for="col in customColumns"
+						:key="col.id"
+						class="day-column custom-column">
+						<div class="day-header custom-column-header">
+							<input
+								class="custom-column-title"
+								:value="col.title"
+								placeholder="Column title…"
+								@input="updateColumnTitle(col.id, ($event.target as HTMLInputElement).value)"
+								@keydown.enter="($event.target as HTMLInputElement).blur()">
+						</div>
+						<div class="day-tasks">
+							<draggable
+								v-model="col.tasks"
+								group="weekGroup"
+								item-key="id"
+								class="task-list"
+								@change="onCustomOrWeekDragChange">
+								<template #item="{ element }: { element: Task }">
+									<div class="task-item" :class="{ done: element.done }">
+										<span class="task-title" @click="openEdit(col.id, element)">
+											{{ element.title }}
+										</span>
+										<svg v-if="element.notes"
+											class="task-notes-icon"
+											xmlns="http://www.w3.org/2000/svg"
+											viewBox="0 0 24 24"
+											width="20"
+											height="20"
+											fill="currentColor">
+											<path d="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M14,18H6V16H14V18M18,14H6V12H18V14M13,9V3.5L18.5,9H13Z" />
+										</svg>
+										<button
+											class="task-check"
+											:class="{ checked: element.done }"
+											@click.stop="toggleCustomDone(col.id, element.id)">
+											<svg v-if="element.done"
+												xmlns="http://www.w3.org/2000/svg"
+												viewBox="0 0 24 24"
+												width="20"
+												height="20">
+												<circle cx="12"
+													cy="12"
+													r="10"
+													fill="var(--color-primary-element)"
+													stroke="var(--color-primary-element)"
+													stroke-width="1.5" />
+												<path d="M8 12l2.5 2.5L16 9"
+													fill="none"
+													stroke="white"
+													stroke-width="2"
+													stroke-linecap="round"
+													stroke-linejoin="round" />
+											</svg>
+											<template v-else>
+												<svg class="check-idle"
+													xmlns="http://www.w3.org/2000/svg"
+													viewBox="0 0 24 24"
+													width="20"
+													height="20">
+													<circle cx="12"
+														cy="12"
+														r="10"
+														fill="none"
+														stroke="currentColor"
+														stroke-width="1.5" />
+												</svg>
+												<svg class="check-hover"
+													xmlns="http://www.w3.org/2000/svg"
+													viewBox="0 0 24 24"
+													width="20"
+													height="20">
+													<circle cx="12"
+														cy="12"
+														r="10"
+														fill="var(--color-primary-element)"
+														stroke="var(--color-primary-element)"
+														stroke-width="1.5" />
+													<path d="M8 12l2.5 2.5L16 9"
+														fill="none"
+														stroke="white"
+														stroke-width="2"
+														stroke-linecap="round"
+														stroke-linejoin="round" />
+												</svg>
+											</template>
+										</button>
+									</div>
+								</template>
+							</draggable>
+							<div class="task-add">
+								<input
+									v-model="newCustomTasks[col.id]"
+									class="task-input"
+									placeholder="Add task…"
+									@keydown.enter="addCustomTask(col.id)">
+								<button class="task-add-btn" @click="addCustomTask(col.id)">
+									+
+								</button>
+							</div>
+						</div>
+					</div>
+				</div>
+
 				<!-- Edit Task Dialog -->
 				<div v-if="editingTask" class="edit-overlay" @click.self="saveEdit">
 					<div class="edit-dialog" @keydown.escape="saveEdit">
@@ -852,14 +852,13 @@ onUnmounted(() => {
 
 .week-grid {
 	display: grid;
-	grid-template-columns: repeat(5, 1fr);
-	grid-template-rows: 3fr 1fr;
+	grid-template-columns: repeat(5, 1fr) 0.8fr;
 	gap: 1px;
 	flex: 1;
 	min-height: 0;
 	background-color: var(--color-border);
 	border: 1px solid var(--color-border);
-	border-radius: 8px;
+	border-radius: 8px 8px 0 0;
 	overflow: hidden;
 }
 
@@ -868,14 +867,6 @@ onUnmounted(() => {
 	flex-direction: column;
 	background-color: var(--color-main-background);
 	min-height: 0;
-}
-
-.weekday-column {
-	grid-row: 1;
-}
-
-.bottom-column {
-	grid-row: 2;
 }
 
 .weekend-column {
@@ -1062,6 +1053,18 @@ onUnmounted(() => {
 }
 
 /* Custom columns */
+.custom-columns-grid {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	gap: 1px;
+	min-height: 120px;
+	background-color: var(--color-border);
+	border: 1px solid var(--color-border);
+	border-top: none;
+	border-radius: 0 0 8px 8px;
+	overflow: hidden;
+}
+
 .custom-column-header {
 	display: flex;
 	align-items: center;
@@ -1231,18 +1234,22 @@ onUnmounted(() => {
 
 	.week-grid {
 		grid-template-columns: 1fr;
-		grid-template-rows: none;
 		overflow: visible;
+		border-radius: 8px;
 	}
 
-	.weekday-column,
-	.bottom-column {
-		grid-row: auto;
+	.custom-columns-grid {
+		grid-template-columns: 1fr;
+		border-top: 1px solid var(--color-border);
+		border-radius: 8px;
+		margin-top: 8px;
+		min-height: unset;
 	}
 
 	.day-column,
 	.weekend-column,
-	.weekend-half {
+	.weekend-half,
+	.custom-column {
 		min-height: unset;
 	}
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -1057,7 +1057,8 @@ onUnmounted(() => {
 	display: grid;
 	grid-template-columns: repeat(3, 1fr);
 	gap: 1px;
-	height: 180px;
+	height: 30vh;
+	min-height: 200px;
 	flex-shrink: 0;
 	background-color: var(--color-border);
 	border: 1px solid var(--color-border);
@@ -1234,28 +1235,22 @@ onUnmounted(() => {
 	}
 
 	.week-grid {
-		grid-template-columns: 1fr;
-		overflow: visible;
-		border-radius: 8px;
+		grid-template-columns: repeat(5, minmax(140px, 1fr)) minmax(120px, 0.8fr);
+		overflow-x: auto;
+		border-radius: 8px 8px 0 0;
+		flex: 1;
 	}
 
 	.custom-columns-grid {
 		grid-template-columns: 1fr;
 		border-top: 1px solid var(--color-border);
-		border-radius: 8px;
-		margin-top: 8px;
+		border-radius: 0 0 8px 8px;
+		height: auto;
 		min-height: unset;
 	}
 
-	.day-column,
-	.weekend-column,
-	.weekend-half,
 	.custom-column {
-		min-height: unset;
-	}
-
-	.day-tasks {
-		overflow-y: visible;
+		min-height: 80px;
 	}
 
 	.edit-dialog {

--- a/src/App.vue
+++ b/src/App.vue
@@ -1057,7 +1057,8 @@ onUnmounted(() => {
 	display: grid;
 	grid-template-columns: repeat(3, 1fr);
 	gap: 1px;
-	min-height: 120px;
+	height: 180px;
+	flex-shrink: 0;
 	background-color: var(--color-border);
 	border: 1px solid var(--color-border);
 	border-top: none;


### PR DESCRIPTION
## Summary
This PR adds a custom columns feature to the week planner, allowing users to create and manage custom task columns that persist across weeks. Custom columns are stored separately from weekly data and can be dragged between the weekly grid and custom columns.

## Key Changes

### Frontend (Vue Component)
- Added `CustomColumn` interface to define custom column structure with id, title, and tasks
- Implemented custom columns state management with three default columns (two empty, one "Someday")
- Added functions to manage custom columns:
  - `loadCustomColumns()` - Load persisted custom columns from backend
  - `addCustomTask()` - Add task to custom column
  - `toggleCustomDone()` - Toggle task completion status
  - `deleteCustomTask()` - Remove task from custom column
  - `updateColumnTitle()` - Edit column title
  - `debouncedSaveCustomColumns()` - Persist changes with debouncing
- Extended edit dialog to support both weekly and custom column tasks
- Added drag-and-drop support between weekly grid and custom columns via shared `weekGroup`
- Updated lifecycle hooks to load custom columns on mount and cleanup on unmount
- Added responsive grid layout for custom columns (3 columns on desktop, 1 on mobile)

### Backend (PHP)
- Created `CustomColumnsController` with GET/PUT endpoints for managing custom columns
- Implemented `CustomColumns` entity class for database representation
- Created `CustomColumnsMapper` for database queries
- Added database migration to create `weekplanner_custom_columns` table with:
  - `id` (primary key)
  - `user_id` (unique constraint)
  - `data` (JSON storage for columns)
  - `updated_at` (timestamp)

## Notable Implementation Details
- Custom columns persist independently from weekly data, allowing them to carry across week changes
- Drag-and-drop uses a shared group (`weekGroup`) enabling tasks to move between weekly and custom columns
- Column titles are editable inline with placeholder text
- All changes are debounced (300ms) to reduce database writes
- Default state includes three columns: two empty and one labeled "Someday"
- Responsive design adjusts custom columns grid from 3 columns to 1 column on mobile
- Weekly grid border-radius adjusted to accommodate custom columns below

https://claude.ai/code/session_01Mo1sfVUaWYo4tiHv1zKdD4