### PR TITLE
Add Docker Compose configuration for local Nextcloud development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   nextcloud:
     image: nextcloud:32
+    entrypoint: /custom-entrypoint.sh
     ports:
       - "8080:80"
     volumes:
@@ -8,6 +9,7 @@ services:
       # Mount the app source directly into Nextcloud's custom_apps directory.
       # Any local changes (including `pnpm run build`) are reflected immediately.
       - .:/var/www/html/custom_apps/weekplanner
+      - ./docker-entrypoint.sh:/custom-entrypoint.sh:ro
     environment:
       - SQLITE_DATABASE=nextcloud
       - NEXTCLOUD_ADMIN_USER=admin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  nextcloud:
+    image: nextcloud:32
+    ports:
+      - "8080:80"
+    volumes:
+      - nextcloud_data:/var/www/html
+      # Mount the app source directly into Nextcloud's custom_apps directory.
+      # Any local changes (including `pnpm run build`) are reflected immediately.
+      - .:/var/www/html/custom_apps/weekplanner
+    environment:
+      - SQLITE_DATABASE=nextcloud
+      - NEXTCLOUD_ADMIN_USER=admin
+      - NEXTCLOUD_ADMIN_PASSWORD=admin
+    restart: unless-stopped
+
+volumes:
+  nextcloud_data:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+
+# Run the default Nextcloud entrypoint (installs/upgrades Nextcloud)
+/entrypoint.sh apache2-foreground &
+
+# Wait until Nextcloud is fully installed before enabling the app
+until php occ status --output=json 2>/dev/null | grep -q '"installed":true'; do
+  echo "Waiting for Nextcloud to finish installing…"
+  sleep 2
+done
+
+php occ app:enable weekplanner || true
+echo "weekplanner app enabled"
+
+# Keep the container alive by waiting on Apache
+wait


### PR DESCRIPTION
## Summary
This PR adds a Docker Compose configuration file to enable local development of the Weekplanner app within a Nextcloud environment.

## Key Changes
- Added `docker-compose.yml` with a Nextcloud 32 service configured for development
- Configured volume mounts to:
  - Persist Nextcloud data in a named volume
  - Mount the local app source directly into Nextcloud's `custom_apps/weekplanner` directory for hot-reloading during development
- Set up SQLite database with default admin credentials (`admin`/`admin`)
- Exposed Nextcloud on port 8080 for local access
- Configured automatic restart policy for the service

## Implementation Details
The Docker Compose setup allows developers to:
- Run a complete Nextcloud instance locally without manual installation
- See changes immediately as the app source is mounted directly into the custom apps directory
- Build and test the Weekplanner app in a realistic Nextcloud environment

https://claude.ai/code/session_0191CQmPXg8eix9cYLL2AGzb