### PR TITLE
Add task color support with color picker UI

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -20,7 +20,7 @@ A simple weekly planner inspired by [Tweek](https://tweek.so), living right insi
 - **📱 Mobile friendly:** The interface works well on smaller screens so you can plan on the go.
 - **🧩 Nextcloud native:** Fully integrated into the Nextcloud navigation — no external accounts, no third-party sync, no tracking.
   ]]></description>
-  <version>1.4.4</version>
+  <version>1.5.0</version>
   <licence>AGPL-3.0-or-later</licence>
 
   <author mail="soeren@soeren.codes" homepage="https://www.soeren.codes">Sören Johanson</author>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weekplanner",
-  "version": "1.4.4",
+  "version": "1.5.0",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -39,7 +39,7 @@ const recurring = useRecurringTasks(
 )
 
 const {
-	editingTask, editTitle, editNotes, editRecurrence,
+	editingTask, editTitle, editNotes, editRecurrence, editColor,
 	newTasks, openEdit, saveEdit, deleteEditingTask, addTask, toggleDone,
 } = useTaskEditing(
 	currentYear, currentWeek, weekData, weekDates, recurringTasks,
@@ -196,9 +196,11 @@ onUnmounted(() => {
 					:title="editTitle"
 					:notes="editNotes"
 					:recurrence="editRecurrence"
+					:color="editColor"
 					@update:title="editTitle = $event"
 					@update:notes="editNotes = $event"
 					@update:recurrence="editRecurrence = $event"
+					@update:color="editColor = $event"
 					@save="saveEdit"
 					@delete="deleteEditingTask" />
 			</div>

--- a/src/components/EditDialog.vue
+++ b/src/components/EditDialog.vue
@@ -254,6 +254,8 @@ onMounted(() => {
 .edit-color-swatch {
 	width: 28px;
 	height: 28px;
+	min-width: 28px;
+	min-height: 28px;
 	border-radius: 50%;
 	border: 2px solid var(--color-border-dark);
 	cursor: pointer;
@@ -263,6 +265,8 @@ onMounted(() => {
 	justify-content: center;
 	background: none;
 	transition: border-color 0.15s, transform 0.15s;
+	box-sizing: content-box;
+	flex-shrink: 0;
 }
 
 .edit-color-swatch:hover {

--- a/src/components/EditDialog.vue
+++ b/src/components/EditDialog.vue
@@ -85,7 +85,11 @@ onMounted(() => {
 						:class="{ selected: !color }"
 						title="No color"
 						@click="$emit('update:color', '')">
-						<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="14" height="14" fill="currentColor">
+						<svg xmlns="http://www.w3.org/2000/svg"
+							viewBox="0 0 24 24"
+							width="14"
+							height="14"
+							fill="currentColor">
 							<path d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z" />
 						</svg>
 					</button>

--- a/src/components/EditDialog.vue
+++ b/src/components/EditDialog.vue
@@ -1,18 +1,21 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import NcButton from '@nextcloud/vue/components/NcButton'
-import type { Recurrence } from '../types'
+import type { Recurrence, TaskColor } from '../types'
+import { TASK_COLORS } from '../types'
 
 defineProps<{
 	title: string
 	notes: string
 	recurrence: Recurrence
+	color: TaskColor
 }>()
 
 defineEmits<{
 	'update:title': [value: string]
 	'update:notes': [value: string]
 	'update:recurrence': [value: Recurrence]
+	'update:color': [value: TaskColor]
 	save: []
 	delete: []
 }>()
@@ -75,6 +78,26 @@ onMounted(() => {
 						Monthly
 					</option>
 				</select>
+				<label class="edit-label edit-label-color">Color</label>
+				<div class="edit-color-picker">
+					<button
+						class="edit-color-swatch edit-color-none"
+						:class="{ selected: !color }"
+						title="No color"
+						@click="$emit('update:color', '')">
+						<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="14" height="14" fill="currentColor">
+							<path d="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z" />
+						</svg>
+					</button>
+					<button
+						v-for="c in TASK_COLORS"
+						:key="c.value"
+						class="edit-color-swatch"
+						:class="{ selected: color === c.value }"
+						:style="{ backgroundColor: c.hex }"
+						:title="c.label"
+						@click="$emit('update:color', c.value)" />
+				</div>
 			</div>
 			<div class="edit-dialog-footer">
 				<NcButton type="primary" @click="$emit('save')">
@@ -216,6 +239,44 @@ onMounted(() => {
 
 .edit-recurrence-select:focus {
 	border-color: var(--color-primary-element);
+}
+
+.edit-label-color {
+	margin-top: 16px;
+}
+
+.edit-color-picker {
+	display: flex;
+	gap: 8px;
+	flex-wrap: wrap;
+}
+
+.edit-color-swatch {
+	width: 28px;
+	height: 28px;
+	border-radius: 50%;
+	border: 2px solid var(--color-border-dark);
+	cursor: pointer;
+	padding: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: none;
+	transition: border-color 0.15s, transform 0.15s;
+}
+
+.edit-color-swatch:hover {
+	transform: scale(1.15);
+}
+
+.edit-color-swatch.selected {
+	border-color: var(--color-main-text);
+	box-shadow: 0 0 0 2px var(--color-main-background), 0 0 0 4px var(--color-main-text);
+}
+
+.edit-color-none {
+	background-color: var(--color-main-background);
+	color: var(--color-text-maxcontrast);
 }
 
 .edit-dialog-footer {

--- a/src/components/EditDialog.vue
+++ b/src/components/EditDialog.vue
@@ -271,7 +271,6 @@ onMounted(() => {
 
 .edit-color-swatch.selected {
 	border-color: var(--color-main-text);
-	box-shadow: 0 0 0 2px var(--color-main-background), 0 0 0 4px var(--color-main-text);
 }
 
 .edit-color-none {

--- a/src/components/TaskItem.vue
+++ b/src/components/TaskItem.vue
@@ -25,6 +25,7 @@ function colorHex(color: string): string | undefined {
 			@click="$emit('edit', task)">
 			{{ task.title }}
 		</span>
+		<span v-if="task.color" class="task-spacer" @click="$emit('edit', task)" />
 		<svg v-if="task.notes"
 			class="task-notes-icon"
 			xmlns="http://www.w3.org/2000/svg"
@@ -124,16 +125,25 @@ function colorHex(color: string): string | undefined {
 }
 
 .task-title {
-	flex: 1;
 	cursor: pointer;
 	font-size: 13px;
 	overflow-wrap: break-word;
+	min-width: 0;
+}
+
+.task-title:not(.task-title-colored) {
+	flex: 1;
 }
 
 .task-title-colored {
 	padding: 2px 8px;
-	border-radius: 12px;
+	border-radius: 8px;
 	color: #000;
+}
+
+.task-spacer {
+	flex: 1;
+	cursor: pointer;
 }
 
 .task-item.done .task-title {

--- a/src/components/TaskItem.vue
+++ b/src/components/TaskItem.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { Task } from '../types'
+import { TASK_COLORS } from '../types'
 
 defineProps<{
 	task: Task
@@ -9,11 +10,19 @@ defineEmits<{
 	edit: [task: Task]
 	toggleDone: [taskId: string]
 }>()
+
+function colorHex(color: string): string | undefined {
+	return TASK_COLORS.find((c) => c.value === color)?.hex
+}
 </script>
 
 <template>
 	<div class="task-item" :class="{ done: task.done }">
-		<span class="task-title" @click="$emit('edit', task)">
+		<span
+			class="task-title"
+			:class="{ 'task-title-colored': task.color }"
+			:style="task.color ? { backgroundColor: colorHex(task.color) } : undefined"
+			@click="$emit('edit', task)">
 			{{ task.title }}
 		</span>
 		<svg v-if="task.notes"
@@ -119,6 +128,12 @@ defineEmits<{
 	cursor: pointer;
 	font-size: 13px;
 	overflow-wrap: break-word;
+}
+
+.task-title-colored {
+	padding: 2px 8px;
+	border-radius: 12px;
+	color: #000;
 }
 
 .task-item.done .task-title {

--- a/src/composables/__tests__/useTaskEditing.test.ts
+++ b/src/composables/__tests__/useTaskEditing.test.ts
@@ -90,7 +90,7 @@ describe('useTaskEditing', () => {
 	describe('toggleDone', () => {
 		it('toggles the done state of a task', () => {
 			const week = emptyWeek()
-			const task: Task = { id: 't1', title: 'Test', done: false, notes: '', recurrence: '' }
+			const task: Task = { id: 't1', title: 'Test', done: false, notes: '', recurrence: '', color: '' }
 			week.days.monday.push(task)
 			const { toggleDone, weekData, debouncedSave } = setup({ weekOverride: week })
 
@@ -107,7 +107,7 @@ describe('useTaskEditing', () => {
 	describe('openEdit / saveEdit', () => {
 		it('opens edit dialog with task data', () => {
 			const week = emptyWeek()
-			const task: Task = { id: 't1', title: 'Hello', done: false, notes: 'some notes', recurrence: 'weekly' }
+			const task: Task = { id: 't1', title: 'Hello', done: false, notes: 'some notes', recurrence: 'weekly', color: '' }
 			week.days.wednesday.push(task)
 			const { openEdit, editingTask, editTitle, editNotes, editRecurrence } = setup({ weekOverride: week })
 
@@ -121,7 +121,7 @@ describe('useTaskEditing', () => {
 
 		it('saves edited title and notes', () => {
 			const week = emptyWeek()
-			const task: Task = { id: 't1', title: 'Old', done: false, notes: '', recurrence: '' }
+			const task: Task = { id: 't1', title: 'Old', done: false, notes: '', recurrence: '', color: '' }
 			week.days.friday.push(task)
 			const { openEdit, saveEdit, editTitle, editNotes, weekData, editingTask, debouncedSave } = setup({ weekOverride: week })
 
@@ -138,7 +138,7 @@ describe('useTaskEditing', () => {
 
 		it('does not save empty title — keeps original', () => {
 			const week = emptyWeek()
-			const task: Task = { id: 't1', title: 'Original', done: false, notes: '', recurrence: '' }
+			const task: Task = { id: 't1', title: 'Original', done: false, notes: '', recurrence: '', color: '' }
 			week.days.monday.push(task)
 			const { openEdit, saveEdit, editTitle, weekData } = setup({ weekOverride: week })
 
@@ -153,7 +153,7 @@ describe('useTaskEditing', () => {
 	describe('saveEdit with recurrence changes', () => {
 		it('creates a recurring definition when setting recurrence', () => {
 			const week = emptyWeek()
-			const task: Task = { id: 't1', title: 'Standup', done: false, notes: '', recurrence: '' }
+			const task: Task = { id: 't1', title: 'Standup', done: false, notes: '', recurrence: '', color: '' }
 			week.days.wednesday.push(task)
 			const {
 				openEdit, saveEdit, editRecurrence, recurringTasks,
@@ -182,6 +182,7 @@ describe('useTaskEditing', () => {
 				done: false,
 				notes: '',
 				recurrence: 'daily',
+				color: '',
 				recurringSourceId: defId,
 			}
 			week.days.wednesday.push(task)
@@ -192,6 +193,7 @@ describe('useTaskEditing', () => {
 				done: false,
 				notes: '',
 				recurrence: 'daily',
+				color: '',
 				recurringSourceId: defId,
 			})
 			week.days.friday.push({
@@ -200,6 +202,7 @@ describe('useTaskEditing', () => {
 				done: false,
 				notes: '',
 				recurrence: 'daily',
+				color: '',
 				recurringSourceId: defId,
 			})
 			const defs: RecurringTaskDefinition[] = [{
@@ -235,6 +238,7 @@ describe('useTaskEditing', () => {
 				done: false,
 				notes: '',
 				recurrence: 'daily',
+				color: '',
 				recurringSourceId: defId,
 			}
 			week.days.wednesday.push(task)
@@ -270,6 +274,7 @@ describe('useTaskEditing', () => {
 				done: false,
 				notes: 'old notes',
 				recurrence: 'weekly',
+				color: '',
 				recurringSourceId: defId,
 			}
 			week.days.friday.push(task)
@@ -303,7 +308,7 @@ describe('useTaskEditing', () => {
 			const columns: CustomColumn[] = [{
 				id: 'custom_1',
 				title: 'Someday',
-				tasks: [{ id: 't1', title: 'Old', done: false, notes: '', recurrence: '' }],
+				tasks: [{ id: 't1', title: 'Old', done: false, notes: '', recurrence: '', color: '' }],
 			}]
 			const { openEdit, saveEdit, editTitle, editNotes, customColumns, debouncedSaveCustomColumns } = setup({ columns })
 
@@ -321,7 +326,7 @@ describe('useTaskEditing', () => {
 	describe('deleteEditingTask', () => {
 		it('deletes a regular task', () => {
 			const week = emptyWeek()
-			const task: Task = { id: 't1', title: 'Delete me', done: false, notes: '', recurrence: '' }
+			const task: Task = { id: 't1', title: 'Delete me', done: false, notes: '', recurrence: '', color: '' }
 			week.days.tuesday.push(task)
 			const { openEdit, deleteEditingTask, weekData, editingTask, debouncedSave } = setup({ weekOverride: week })
 
@@ -342,6 +347,7 @@ describe('useTaskEditing', () => {
 				done: false,
 				notes: '',
 				recurrence: 'daily',
+				color: '',
 				recurringSourceId: defId,
 			}
 			week.days.wednesday.push(task)
@@ -351,6 +357,7 @@ describe('useTaskEditing', () => {
 				done: false,
 				notes: '',
 				recurrence: 'daily',
+				color: '',
 				recurringSourceId: defId,
 			})
 			week.days.friday.push({
@@ -359,6 +366,7 @@ describe('useTaskEditing', () => {
 				done: false,
 				notes: '',
 				recurrence: 'daily',
+				color: '',
 				recurringSourceId: defId,
 			})
 			// Monday and Tuesday have instances too
@@ -368,6 +376,7 @@ describe('useTaskEditing', () => {
 				done: false,
 				notes: '',
 				recurrence: 'daily',
+				color: '',
 				recurringSourceId: defId,
 			})
 			const defs: RecurringTaskDefinition[] = [{
@@ -407,7 +416,7 @@ describe('useTaskEditing', () => {
 			const columns: CustomColumn[] = [{
 				id: 'custom_1',
 				title: 'Someday',
-				tasks: [{ id: 't1', title: 'Custom task', done: false, notes: '', recurrence: '' }],
+				tasks: [{ id: 't1', title: 'Custom task', done: false, notes: '', recurrence: '', color: '' }],
 			}]
 			const { openEdit, deleteEditingTask, deleteCustomTask, editingTask } = setup({ columns })
 

--- a/src/composables/useCustomColumns.ts
+++ b/src/composables/useCustomColumns.ts
@@ -81,6 +81,7 @@ export function useCustomColumns(recurringTasks: Ref<RecurringTaskDefinition[]>)
 			done: false,
 			notes: '',
 			recurrence: '',
+			color: '',
 		})
 		newCustomTasks.value[columnId] = ''
 		debouncedSaveCustomColumns()

--- a/src/composables/useRecurringTasks.ts
+++ b/src/composables/useRecurringTasks.ts
@@ -60,6 +60,7 @@ export function useRecurringTasks(
 						done: false,
 						notes: def.notes,
 						recurrence: def.recurrence,
+						color: '',
 						recurringSourceId: def.id,
 					})
 					changed = true

--- a/src/composables/useTaskEditing.ts
+++ b/src/composables/useTaskEditing.ts
@@ -1,6 +1,6 @@
 import { ref, nextTick } from 'vue'
 import type { Ref, ComputedRef } from 'vue'
-import type { Recurrence, Task, RecurringTaskDefinition, DayKey, WeekData, CustomColumn } from '../types'
+import type { Recurrence, TaskColor, Task, RecurringTaskDefinition, DayKey, WeekData, CustomColumn } from '../types'
 import { ALL_KEYS } from '../types'
 import { getWeekDates, toDateStr } from '../utils/dateUtils'
 
@@ -24,6 +24,7 @@ export function useTaskEditing(
 	const editTitle = ref('')
 	const editNotes = ref('')
 	const editRecurrence = ref<Recurrence>('')
+	const editColor = ref<TaskColor>('')
 	const editTitleInput = ref<HTMLInputElement | null>(null)
 
 	const newTasks = ref<Record<DayKey, string>>({
@@ -45,6 +46,7 @@ export function useTaskEditing(
 		editTitle.value = task.title
 		editNotes.value = task.notes || ''
 		editRecurrence.value = task.recurrence || ''
+		editColor.value = task.color || ''
 		nextTick(() => {
 			editTitleInput.value?.focus()
 		})
@@ -124,6 +126,7 @@ export function useTaskEditing(
 					task.title = editTitle.value.trim() || task.title
 					task.notes = editNotes.value
 					task.recurrence = editRecurrence.value
+					task.color = editColor.value
 					debouncedSaveCustomColumns()
 				}
 			}
@@ -133,6 +136,7 @@ export function useTaskEditing(
 				const oldRecurrence = task.recurrence || ''
 				task.title = editTitle.value.trim() || task.title
 				task.notes = editNotes.value
+				task.color = editColor.value
 				// Handle recurrence changes
 				if (editRecurrence.value !== oldRecurrence) {
 					handleRecurrenceChange(task, day as DayKey)
@@ -197,6 +201,7 @@ export function useTaskEditing(
 			done: false,
 			notes: '',
 			recurrence: '',
+			color: '',
 		})
 		newTasks.value[day] = ''
 		debouncedSave()
@@ -215,6 +220,7 @@ export function useTaskEditing(
 		editTitle,
 		editNotes,
 		editRecurrence,
+		editColor,
 		editTitleInput,
 		newTasks,
 		openEdit,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,23 @@
 export type Recurrence = '' | 'daily' | 'weekly' | 'monthly'
 
+export type TaskColor = '' | 'red' | 'orange' | 'yellow' | 'green' | 'blue' | 'purple'
+
+export const TASK_COLORS: { value: TaskColor; label: string; hex: string }[] = [
+	{ value: 'red', label: 'Red', hex: '#FFD4D4' },
+	{ value: 'orange', label: 'Orange', hex: '#FFE4C8' },
+	{ value: 'yellow', label: 'Yellow', hex: '#FFF3C4' },
+	{ value: 'green', label: 'Green', hex: '#D4F5D4' },
+	{ value: 'blue', label: 'Blue', hex: '#D4E8FF' },
+	{ value: 'purple', label: 'Purple', hex: '#E8D4FF' },
+]
+
 export interface Task {
 	id: string
 	title: string
 	done: boolean
 	notes: string
 	recurrence: Recurrence
+	color: TaskColor
 	recurringSourceId?: string
 }
 

--- a/src/utils/weekData.ts
+++ b/src/utils/weekData.ts
@@ -27,6 +27,7 @@ export function normalizeWeekData(data: unknown): WeekData {
 							...t,
 							notes: t.notes || '',
 							recurrence: t.recurrence || '',
+							color: t.color || '',
 						}
 						if (t.recurringSourceId) {
 							task.recurringSourceId = t.recurringSourceId

--- a/tests/Controller/CustomColumnsControllerTest.php
+++ b/tests/Controller/CustomColumnsControllerTest.php
@@ -52,6 +52,7 @@ class CustomColumnsControllerTest extends TestCase {
 				['id' => 'custom_2', 'title' => '', 'tasks' => []],
 				['id' => 'custom_3', 'title' => '', 'tasks' => []],
 			],
+			'recurringTasks' => [],
 		];
 	}
 


### PR DESCRIPTION
## Summary
This PR adds color tagging functionality to tasks, allowing users to assign one of six predefined colors to tasks for better visual organization and categorization.

## Key Changes
- **New type definitions**: Added `TaskColor` type and `TASK_COLORS` constant with six color options (red, orange, yellow, green, blue, purple) including hex values and labels
- **Task model update**: Extended `Task` interface with a new `color` property of type `TaskColor`
- **Edit dialog enhancement**: 
  - Added color picker UI with circular color swatches and a "no color" option
  - Implemented color selection with visual feedback (hover scale effect, selected border highlight)
  - Added `update:color` emit for two-way binding
- **Task item display**: 
  - Tasks with assigned colors now display with a colored background badge on the title
  - Added visual spacing between colored title and action icons
  - Implemented `colorHex()` helper function to map color values to hex codes
- **State management**: Updated `useTaskEditing` composable to track and persist color changes alongside other task properties
- **Data persistence**: Updated all task creation points and data normalization to include the `color` field with empty string as default
- **Test updates**: Updated all test fixtures to include the new `color` property in task objects

## Implementation Details
- Color swatches are displayed as circular buttons with smooth transitions
- The "no color" option shows an X icon and uses the main background color
- Color selection is immediately reflected in the UI with a border highlight
- All existing task creation flows (new tasks, recurring tasks, custom columns) properly initialize the color field
- Data normalization ensures backward compatibility by defaulting missing color values to empty string

https://claude.ai/code/session_01XXtrPyPVimi19Fsp9es8b3