### PR TITLE
Add margin to task item color badges

### DIFF
--- a/src/components/TaskItem.vue
+++ b/src/components/TaskItem.vue
@@ -139,6 +139,7 @@ function colorHex(color: string): string | undefined {
 	padding: 2px 8px;
 	border-radius: 8px;
 	color: #000;
+	margin-right: 4px;
 }
 
 .task-spacer {


### PR DESCRIPTION
## Summary
Added right margin spacing to color badge elements in the TaskItem component to improve visual separation between badges and adjacent content.

## Changes
- Added `margin-right: 4px;` to the color badge styling in TaskItem.vue

## Details
This small spacing adjustment ensures that color badges have proper visual separation from any content that follows them, improving the overall layout and readability of task items.

https://claude.ai/code/session_01RmjhqWS7bvpEJeaMHk9Dkn