### PR TITLE
fix: mobile view day columns with minimum height and no inner scroll

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -20,7 +20,7 @@ A simple weekly planner inspired by [Tweek](https://tweek.so), living right insi
 - **📱 Mobile friendly:** The interface works well on smaller screens so you can plan on the go.
 - **🧩 Nextcloud native:** Fully integrated into the Nextcloud navigation — no external accounts, no third-party sync, no tracking.
   ]]></description>
-  <version>1.6.0</version>
+  <version>1.6.1</version>
   <licence>AGPL-3.0-or-later</licence>
 
   <author mail="soeren@soeren.codes" homepage="https://www.soeren.codes">Sören Johanson</author>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weekplanner",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -369,12 +369,15 @@ onUnmounted(() => {
 		flex-direction: column;
 		gap: 0;
 		flex: none;
+		height: auto;
+		min-height: unset;
 		overflow: visible;
 		border-radius: 8px 8px 0 0;
 	}
 
-	.week-grid .day-column {
-		min-height: auto;
+	.week-grid .day-column,
+	.week-grid .weekend-half {
+		min-height: 80px;
 	}
 
 	.week-grid .weekend-column {

--- a/src/components/EditDialog.vue
+++ b/src/components/EditDialog.vue
@@ -23,7 +23,10 @@ defineEmits<{
 const titleInput = ref<HTMLInputElement | null>(null)
 
 onMounted(() => {
-	titleInput.value?.focus()
+	const isMobile = window.matchMedia('(max-width: 768px)').matches
+	if (!isMobile) {
+		titleInput.value?.focus()
+	}
 })
 </script>
 

--- a/src/components/TaskList.vue
+++ b/src/components/TaskList.vue
@@ -111,7 +111,7 @@ defineEmits<{
 
 	.task-list {
 		overflow-y: visible;
-		min-height: 40px;
+		min-height: 100px;
 	}
 
 	.task-add {

--- a/src/components/TaskList.vue
+++ b/src/components/TaskList.vue
@@ -25,6 +25,8 @@ defineEmits<{
 			group="weekGroup"
 			item-key="id"
 			class="task-list"
+			:delay="200"
+			:delay-on-touch-only="true"
 			@update:model-value="$emit('update:tasks', $event)"
 			@change="$emit('change')">
 			<template #item="{ element }: { element: Task }">
@@ -113,7 +115,7 @@ defineEmits<{
 	}
 
 	.task-add {
-		border-bottom: 1px solid var(--color-border);
+		border-bottom: 3px solid var(--color-border-dark);
 	}
 }
 </style>

--- a/src/components/TaskList.vue
+++ b/src/components/TaskList.vue
@@ -103,9 +103,13 @@ defineEmits<{
 }
 
 @media (max-width: 768px) {
+	.day-tasks {
+		min-height: 0;
+	}
+
 	.task-list {
 		overflow-y: visible;
-		min-height: 20px;
+		min-height: 40px;
 	}
 
 	.task-add {


### PR DESCRIPTION
- Override desktop 70vh week-grid height to auto on mobile
- Set min-height on day columns and weekend halves so empty days show space for 1-2 tasks
- Ensure task lists don't scroll internally on mobile, showing all tasks

https://claude.ai/code/session_01DiA5FFgiDs9Jj8frxHh3uD