### PR TITLE
fix: Prevent empty state being saved to server

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -20,7 +20,7 @@ A simple weekly planner inspired by [Tweek](https://tweek.so), living right insi
 - **📱 Mobile friendly:** The interface works well on smaller screens so you can plan on the go.
 - **🧩 Nextcloud native:** Fully integrated into the Nextcloud navigation — no external accounts, no third-party sync, no tracking.
   ]]></description>
-  <version>1.6.1</version>
+  <version>1.6.2</version>
   <licence>AGPL-3.0-or-later</licence>
 
   <author mail="soeren@soeren.codes" homepage="https://www.soeren.codes">Sören Johanson</author>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weekplanner",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -60,6 +60,7 @@ const polling = usePolling({
 	materializeRecurringTasks: recurring.materializeRecurringTasks,
 	applyCustomColumnsData: columns.applyCustomColumnsData,
 	isWeekSaveIdle: weekPersistence.isSaveIdle,
+	isWeekLoadIdle: weekPersistence.isLoadIdle,
 	isCustomSaveIdle: columns.isSaveIdle,
 	getWeekKnownUpdatedAt: weekPersistence.getKnownUpdatedAt,
 	setWeekKnownUpdatedAt: weekPersistence.setKnownUpdatedAt,

--- a/src/composables/__tests__/usePolling.test.ts
+++ b/src/composables/__tests__/usePolling.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { ref } from 'vue'
+import { listen } from '@nextcloud/notify_push'
 import { usePolling } from '../usePolling'
 import { emptyWeek } from '../../utils/weekData'
 
@@ -14,8 +15,6 @@ vi.mock('@nextcloud/axios', () => ({
 vi.mock('@nextcloud/router', () => ({
 	generateUrl: () => '/mock/url',
 }))
-
-import { listen } from '@nextcloud/notify_push'
 const mockListen = vi.mocked(listen as (event: string, cb: (type: string, body: unknown) => void) => boolean)
 
 const YEAR = 2026

--- a/src/composables/__tests__/usePolling.test.ts
+++ b/src/composables/__tests__/usePolling.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref } from 'vue'
+import { usePolling } from '../usePolling'
+import { emptyWeek } from '../../utils/weekData'
+
+vi.mock('@nextcloud/notify_push', () => ({
+	listen: vi.fn().mockReturnValue(true),
+}))
+
+vi.mock('@nextcloud/axios', () => ({
+	default: { get: vi.fn() },
+}))
+
+vi.mock('@nextcloud/router', () => ({
+	generateUrl: () => '/mock/url',
+}))
+
+import { listen } from '@nextcloud/notify_push'
+const mockListen = vi.mocked(listen as (event: string, cb: (type: string, body: unknown) => void) => boolean)
+
+const YEAR = 2026
+const WEEK = 12
+
+function setup(overrides: {
+	isWeekSaveIdle?: () => boolean
+	isWeekLoadIdle?: () => boolean
+	isCustomSaveIdle?: () => boolean
+	editingTask?: { day: string; taskId: string } | null
+} = {}) {
+	const loadWeek = vi.fn().mockResolvedValue(undefined)
+	const loadCustomColumns = vi.fn().mockResolvedValue(undefined)
+
+	const polling = usePolling({
+		currentYear: ref(YEAR),
+		currentWeek: ref(WEEK),
+		weekData: ref(emptyWeek()),
+		editingTask: ref(overrides.editingTask ?? null),
+		loadWeek,
+		loadCustomColumns,
+		materializeRecurringTasks: vi.fn(),
+		applyCustomColumnsData: vi.fn(),
+		isWeekSaveIdle: overrides.isWeekSaveIdle ?? (() => true),
+		isWeekLoadIdle: overrides.isWeekLoadIdle ?? (() => true),
+		isCustomSaveIdle: overrides.isCustomSaveIdle ?? (() => true),
+		getWeekKnownUpdatedAt: vi.fn().mockReturnValue(0),
+		setWeekKnownUpdatedAt: vi.fn(),
+		getCustomKnownUpdatedAt: vi.fn().mockReturnValue(0),
+		setCustomKnownUpdatedAt: vi.fn(),
+	})
+
+	return { polling, loadWeek, loadCustomColumns }
+}
+
+function getWeekUpdateListener() {
+	const call = mockListen.mock.calls.find(([event]) => event === 'weekplanner_week_update')
+	return call?.[1]
+}
+
+function fireWeekUpdate(body: unknown) {
+	getWeekUpdateListener()?.('weekplanner_week_update', body)
+}
+
+describe('usePolling', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	describe('notify_push weekplanner_week_update', () => {
+		it('calls loadWeek when all guards pass', async () => {
+			const { polling, loadWeek } = setup()
+			await polling.trySetupNotifyPush()
+
+			fireWeekUpdate({ year: YEAR, week: WEEK })
+
+			expect(loadWeek).toHaveBeenCalledTimes(1)
+		})
+
+		it('does not call loadWeek when a load is already in flight', async () => {
+			const { polling, loadWeek } = setup({ isWeekLoadIdle: () => false })
+			await polling.trySetupNotifyPush()
+
+			fireWeekUpdate({ year: YEAR, week: WEEK })
+
+			expect(loadWeek).not.toHaveBeenCalled()
+		})
+
+		it('does not call loadWeek when a save is in progress', async () => {
+			const { polling, loadWeek } = setup({ isWeekSaveIdle: () => false })
+			await polling.trySetupNotifyPush()
+
+			fireWeekUpdate({ year: YEAR, week: WEEK })
+
+			expect(loadWeek).not.toHaveBeenCalled()
+		})
+
+		it('does not call loadWeek when a task is being edited', async () => {
+			const { polling, loadWeek } = setup({ editingTask: { day: 'monday', taskId: '1' } })
+			await polling.trySetupNotifyPush()
+
+			fireWeekUpdate({ year: YEAR, week: WEEK })
+
+			expect(loadWeek).not.toHaveBeenCalled()
+		})
+
+		it('does not call loadWeek for a different week', async () => {
+			const { polling, loadWeek } = setup()
+			await polling.trySetupNotifyPush()
+
+			fireWeekUpdate({ year: YEAR, week: WEEK + 1 })
+
+			expect(loadWeek).not.toHaveBeenCalled()
+		})
+
+		it('does not call loadWeek for a different year', async () => {
+			const { polling, loadWeek } = setup()
+			await polling.trySetupNotifyPush()
+
+			fireWeekUpdate({ year: YEAR + 1, week: WEEK })
+
+			expect(loadWeek).not.toHaveBeenCalled()
+		})
+
+		it('does not call loadWeek when body is absent', async () => {
+			const { polling, loadWeek } = setup()
+			await polling.trySetupNotifyPush()
+
+			fireWeekUpdate(null)
+
+			expect(loadWeek).not.toHaveBeenCalled()
+		})
+	})
+})

--- a/src/composables/__tests__/useWeekPersistence.test.ts
+++ b/src/composables/__tests__/useWeekPersistence.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ref } from 'vue'
+import type { AxiosRequestConfig } from 'axios'
+import { useWeekPersistence } from '../useWeekPersistence'
+import { emptyWeek } from '../../utils/weekData'
+import type { WeekData } from '../../types'
+
+vi.mock('@nextcloud/axios', () => ({
+	default: { get: vi.fn(), put: vi.fn() },
+}))
+
+vi.mock('@nextcloud/router', () => ({
+	generateUrl: () => '/mock/week/2026/12',
+}))
+
+import axios from '@nextcloud/axios'
+const mockGet = vi.mocked(axios.get)
+const mockPut = vi.mocked(axios.put)
+
+function setup(weekOverride?: WeekData) {
+	const currentYear = ref(2026)
+	const currentWeek = ref(12)
+	const weekData = ref<WeekData>(weekOverride ?? emptyWeek())
+	const onLoaded = vi.fn()
+	const persistence = useWeekPersistence(currentYear, currentWeek, weekData, onLoaded)
+	return { ...persistence, weekData, onLoaded }
+}
+
+function weekWithTask(): WeekData {
+	const week = emptyWeek()
+	week.days.monday = [{ id: '1', title: 'My Task', done: false, notes: '', recurrence: '', color: '' }]
+	return week
+}
+
+function serverResponse(week: WeekData, updatedAt = 100) {
+	return { data: { ...week, updatedAt } }
+}
+
+describe('useWeekPersistence', () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	describe('loadWeek', () => {
+		it('applies response data to weekData on success', async () => {
+			const { loadWeek, weekData } = setup()
+			mockGet.mockResolvedValue(serverResponse(weekWithTask()))
+
+			await loadWeek()
+
+			expect(weekData.value.days.monday).toHaveLength(1)
+			expect(weekData.value.days.monday[0].title).toBe('My Task')
+		})
+
+		it('calls onLoaded after a successful load', async () => {
+			const { loadWeek, onLoaded } = setup()
+			mockGet.mockResolvedValue(serverResponse(emptyWeek()))
+
+			await loadWeek()
+
+			expect(onLoaded).toHaveBeenCalledTimes(1)
+		})
+
+		it('preserves existing weekData when GET fails', async () => {
+			const { loadWeek, weekData } = setup(weekWithTask())
+			mockGet.mockRejectedValue(new Error('Network error'))
+
+			await loadWeek()
+
+			expect(weekData.value.days.monday).toHaveLength(1)
+		})
+
+		it('calls onLoaded even after a failed load', async () => {
+			const { loadWeek, onLoaded } = setup()
+			mockGet.mockRejectedValue(new Error('Network error'))
+
+			await loadWeek()
+
+			expect(onLoaded).toHaveBeenCalledTimes(1)
+		})
+
+		describe('skips applying response when a save is pending', () => {
+			beforeEach(() => vi.useFakeTimers())
+			afterEach(() => vi.useRealTimers())
+
+			it('does not overwrite weekData if saveTimeout is set when response arrives', async () => {
+				const { loadWeek, debouncedSave, weekData } = setup(weekWithTask())
+
+				let resolveGet!: (val: unknown) => void
+				mockGet.mockReturnValue(new Promise(r => { resolveGet = r }))
+
+				const loadPromise = loadWeek()
+				debouncedSave() // sets saveTimeout before GET resolves
+				resolveGet(serverResponse(emptyWeek(), 200))
+				await loadPromise
+
+				expect(weekData.value.days.monday).toHaveLength(1)
+			})
+		})
+
+		it('does not overwrite weekData if a save is in progress when response arrives', async () => {
+			const { loadWeek, saveWeekNow, weekData } = setup(weekWithTask())
+
+			let resolveGet!: (val: unknown) => void
+			mockGet.mockReturnValue(new Promise(r => { resolveGet = r }))
+
+			let resolvePut!: (val: unknown) => void
+			mockPut.mockReturnValue(new Promise(r => { resolvePut = r }))
+
+			const savePromise = saveWeekNow() // isSaving = true
+			const loadPromise = loadWeek()
+
+			resolveGet(serverResponse(emptyWeek(), 200)) // arrives while save in flight
+			await loadPromise
+
+			expect(weekData.value.days.monday).toHaveLength(1)
+
+			resolvePut({ data: { updatedAt: 999 } })
+			await savePromise
+		})
+
+		it('cancels in-flight request when called again', async () => {
+			const { loadWeek, weekData, onLoaded } = setup(weekWithTask())
+
+			let resolveFirst!: (val: unknown) => void
+			let resolveSecond!: (val: unknown) => void
+
+			mockGet
+				.mockImplementationOnce((_url: string, config?: AxiosRequestConfig) =>
+					new Promise((resolve, reject) => {
+						resolveFirst = resolve
+						config?.signal?.addEventListener?.('abort', () =>
+							reject(Object.assign(new Error('AbortError'), { name: 'AbortError' })),
+						)
+					}),
+				)
+				.mockImplementationOnce(() => new Promise(r => { resolveSecond = r }))
+
+			const load1 = loadWeek()
+			const load2 = loadWeek() // aborts load1
+
+			resolveSecond(serverResponse(emptyWeek(), 2))
+			resolveFirst(serverResponse(weekWithTask(), 1)) // already aborted, ignored
+
+			await Promise.all([load1, load2])
+
+			// Only the second response was applied
+			expect(weekData.value.days.monday).toHaveLength(0)
+			// onLoaded called only once — for the completed second request
+			expect(onLoaded).toHaveBeenCalledTimes(1)
+		})
+	})
+
+	describe('isLoadIdle', () => {
+		it('returns true initially', () => {
+			const { isLoadIdle } = setup()
+			expect(isLoadIdle()).toBe(true)
+		})
+
+		it('returns false while a load is in flight', async () => {
+			const { loadWeek, isLoadIdle } = setup()
+
+			let resolveGet!: (val: unknown) => void
+			mockGet.mockReturnValue(new Promise(r => { resolveGet = r }))
+
+			const loadPromise = loadWeek()
+			expect(isLoadIdle()).toBe(false)
+
+			resolveGet(serverResponse(emptyWeek()))
+			await loadPromise
+		})
+
+		it('returns true after a successful load', async () => {
+			const { loadWeek, isLoadIdle } = setup()
+			mockGet.mockResolvedValue(serverResponse(emptyWeek()))
+
+			await loadWeek()
+
+			expect(isLoadIdle()).toBe(true)
+		})
+
+		it('returns true after a failed load', async () => {
+			const { loadWeek, isLoadIdle } = setup()
+			mockGet.mockRejectedValue(new Error('Network error'))
+
+			await loadWeek()
+
+			expect(isLoadIdle()).toBe(true)
+		})
+	})
+})

--- a/src/composables/__tests__/useWeekPersistence.test.ts
+++ b/src/composables/__tests__/useWeekPersistence.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { ref } from 'vue'
-import type { AxiosRequestConfig } from 'axios'
+import axios from '@nextcloud/axios'
 import { useWeekPersistence } from '../useWeekPersistence'
 import { emptyWeek } from '../../utils/weekData'
 import type { WeekData } from '../../types'
@@ -13,7 +13,6 @@ vi.mock('@nextcloud/router', () => ({
 	generateUrl: () => '/mock/week/2026/12',
 }))
 
-import axios from '@nextcloud/axios'
 const mockGet = vi.mocked(axios.get)
 const mockPut = vi.mocked(axios.put)
 
@@ -87,7 +86,7 @@ describe('useWeekPersistence', () => {
 				const { loadWeek, debouncedSave, weekData } = setup(weekWithTask())
 
 				let resolveGet!: (val: unknown) => void
-				mockGet.mockReturnValue(new Promise(r => { resolveGet = r }))
+				mockGet.mockReturnValue(new Promise(resolve => { resolveGet = resolve }))
 
 				const loadPromise = loadWeek()
 				debouncedSave() // sets saveTimeout before GET resolves
@@ -102,10 +101,10 @@ describe('useWeekPersistence', () => {
 			const { loadWeek, saveWeekNow, weekData } = setup(weekWithTask())
 
 			let resolveGet!: (val: unknown) => void
-			mockGet.mockReturnValue(new Promise(r => { resolveGet = r }))
+			mockGet.mockReturnValue(new Promise(resolve => { resolveGet = resolve }))
 
 			let resolvePut!: (val: unknown) => void
-			mockPut.mockReturnValue(new Promise(r => { resolvePut = r }))
+			mockPut.mockReturnValue(new Promise(resolve => { resolvePut = resolve }))
 
 			const savePromise = saveWeekNow() // isSaving = true
 			const loadPromise = loadWeek()
@@ -126,7 +125,7 @@ describe('useWeekPersistence', () => {
 			let resolveSecond!: (val: unknown) => void
 
 			mockGet
-				.mockImplementationOnce((_url: string, config?: AxiosRequestConfig) =>
+				.mockImplementationOnce((_url, config) =>
 					new Promise((resolve, reject) => {
 						resolveFirst = resolve
 						config?.signal?.addEventListener?.('abort', () =>
@@ -134,7 +133,7 @@ describe('useWeekPersistence', () => {
 						)
 					}),
 				)
-				.mockImplementationOnce(() => new Promise(r => { resolveSecond = r }))
+				.mockImplementationOnce(() => new Promise(resolve => { resolveSecond = resolve }))
 
 			const load1 = loadWeek()
 			const load2 = loadWeek() // aborts load1
@@ -161,7 +160,7 @@ describe('useWeekPersistence', () => {
 			const { loadWeek, isLoadIdle } = setup()
 
 			let resolveGet!: (val: unknown) => void
-			mockGet.mockReturnValue(new Promise(r => { resolveGet = r }))
+			mockGet.mockReturnValue(new Promise(resolve => { resolveGet = resolve }))
 
 			const loadPromise = loadWeek()
 			expect(isLoadIdle()).toBe(false)

--- a/src/composables/usePolling.ts
+++ b/src/composables/usePolling.ts
@@ -14,6 +14,7 @@ interface PollDeps {
 	materializeRecurringTasks: () => void
 	applyCustomColumnsData: (data: unknown) => void
 	isWeekSaveIdle: () => boolean
+	isWeekLoadIdle: () => boolean
 	isCustomSaveIdle: () => boolean
 	getWeekKnownUpdatedAt: () => number
 	setWeekKnownUpdatedAt: (val: number) => void
@@ -117,7 +118,7 @@ export function usePolling(deps: PollDeps) {
 			const available = mod.listen('weekplanner_week_update', (_type, body) => {
 				if (!body) return
 				if (Number(body.year) === deps.currentYear.value && Number(body.week) === deps.currentWeek.value) {
-					if (deps.isWeekSaveIdle() && !deps.editingTask.value) {
+					if (deps.isWeekSaveIdle() && deps.isWeekLoadIdle() && !deps.editingTask.value) {
 						deps.loadWeek()
 					}
 				}

--- a/src/composables/useWeekPersistence.ts
+++ b/src/composables/useWeekPersistence.ts
@@ -2,7 +2,7 @@ import type { Ref } from 'vue'
 import axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
 import type { WeekData } from '../types'
-import { emptyWeek, normalizeWeekData } from '../utils/weekData'
+import { normalizeWeekData } from '../utils/weekData'
 
 export function useWeekPersistence(
 	currentYear: Ref<number>,
@@ -12,21 +12,33 @@ export function useWeekPersistence(
 ) {
 	let saveTimeout: ReturnType<typeof setTimeout> | null = null
 	let isSaving = false
+	let isLoading = false
 	let knownWeekUpdatedAt = 0
+	let loadAbortController: AbortController | null = null
 
 	async function loadWeek() {
+		loadAbortController?.abort()
+		const controller = new AbortController()
+		loadAbortController = controller
+		isLoading = true
 		try {
 			const url = generateUrl('/apps/weekplanner/week/{year}/{week}', {
 				year: String(currentYear.value),
 				week: String(currentWeek.value),
 			})
-			const response = await axios.get(url)
+			const response = await axios.get(url, { signal: controller.signal })
+			if (controller.signal.aborted) return
+			// Skip applying if a save is already queued — the pending save is newer
+			if (saveTimeout !== null || isSaving) return
 			weekData.value = normalizeWeekData(response.data)
 			if (typeof response.data?.updatedAt === 'number') {
 				knownWeekUpdatedAt = response.data.updatedAt
 			}
 		} catch {
-			weekData.value = emptyWeek()
+			if (controller.signal.aborted) return
+			// Network/server error: keep existing weekData rather than blanking it
+		} finally {
+			if (!controller.signal.aborted) isLoading = false
 		}
 		onLoaded()
 	}
@@ -76,6 +88,10 @@ export function useWeekPersistence(
 		return saveTimeout === null && !isSaving
 	}
 
+	function isLoadIdle() {
+		return !isLoading
+	}
+
 	return {
 		loadWeek,
 		saveWeekNow,
@@ -84,5 +100,6 @@ export function useWeekPersistence(
 		getKnownUpdatedAt,
 		setKnownUpdatedAt,
 		isSaveIdle,
+		isLoadIdle,
 	}
 }


### PR DESCRIPTION
loadWeek() sometimes ended up saving an empty state to server-side. This happened when the websocket notification failed for whatever reason, because the catch block set weekData.value to an empty week - which would then be caught by the saveTimeout.

This commit fixes that and adds an additional guard against concurrent loadWeek calls + unit tests to prevent this error in the future.