### PR TITLE
Add delete mode selection for recurring tasks

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted, watch } from 'vue'
+import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import NcAppContent from '@nextcloud/vue/components/NcAppContent'
 import NcContent from '@nextcloud/vue/components/NcContent'
 import NcButton from '@nextcloud/vue/components/NcButton'
-import type { RecurringTaskDefinition, WeekData } from './types'
+import type { RecurringTaskDefinition, WeekData, DayKey } from './types'
 import { WEEKDAY_KEYS, WEEKEND_KEYS, DAY_LABELS, ALL_KEYS } from './types'
 import { getWeekDates, toDateStr } from './utils/dateUtils'
 import TaskList from './components/TaskList.vue'
@@ -50,6 +50,18 @@ const {
 	columns.flushCustomSaveTimeout, columns.deleteCustomTask,
 	recurring.materializeRecurringTasks,
 )
+
+const editingTaskIsRecurring = computed(() => {
+	if (!editingTask.value) return false
+	const { day, taskId } = editingTask.value
+	if (day.startsWith('custom_')) {
+		const col = customColumns.value.find((c) => c.id === day)
+		const task = col?.tasks.find((t) => t.id === taskId)
+		return !!task?.recurringSourceId
+	}
+	const task = weekData.value.days[day as DayKey]?.find((t) => t.id === taskId)
+	return !!task?.recurringSourceId
+})
 
 const polling = usePolling({
 	currentYear,
@@ -265,12 +277,13 @@ onUnmounted(() => {
 					:notes="editNotes"
 					:recurrence="editRecurrence"
 					:color="editColor"
+					:is-recurring="editingTaskIsRecurring"
 					@update:title="editTitle = $event"
 					@update:notes="editNotes = $event"
 					@update:recurrence="editRecurrence = $event"
 					@update:color="editColor = $event"
 					@save="saveEdit"
-					@delete="deleteEditingTask" />
+					@delete="deleteEditingTask($event)" />
 			</div>
 		</NcAppContent>
 	</NcContent>

--- a/src/components/EditDialog.vue
+++ b/src/components/EditDialog.vue
@@ -375,8 +375,7 @@ onMounted(() => {
 }
 
 .recurring-delete-header {
-	padding: 16px 20px;
-	border-bottom: 1px solid var(--color-border);
+	padding: 16px 20px 8px;
 }
 
 .recurring-delete-header h3 {
@@ -394,9 +393,8 @@ onMounted(() => {
 .recurring-delete-option {
 	background: none;
 	border: none;
-	border-bottom: 1px solid var(--color-border);
 	cursor: pointer;
-	padding: 14px 20px;
+	padding: 10px 20px;
 	font-size: 14px;
 	color: var(--color-main-text);
 	text-align: left;
@@ -405,10 +403,6 @@ onMounted(() => {
 
 .recurring-delete-option:hover {
 	background-color: var(--color-background-hover);
-}
-
-.recurring-delete-option:last-child {
-	border-bottom: none;
 }
 
 .recurring-delete-footer {

--- a/src/components/EditDialog.vue
+++ b/src/components/EditDialog.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import NcButton from '@nextcloud/vue/components/NcButton'
-import type { Recurrence, TaskColor } from '../types'
+import type { Recurrence, TaskColor, RecurringDeleteMode } from '../types'
 import { TASK_COLORS } from '../types'
 
 defineProps<{
@@ -9,18 +9,29 @@ defineProps<{
 	notes: string
 	recurrence: Recurrence
 	color: TaskColor
+	isRecurring: boolean
 }>()
 
-defineEmits<{
+const emit = defineEmits<{
 	'update:title': [value: string]
 	'update:notes': [value: string]
 	'update:recurrence': [value: Recurrence]
 	'update:color': [value: TaskColor]
 	save: []
-	delete: []
+	delete: [mode?: RecurringDeleteMode]
 }>()
 
 const titleInput = ref<HTMLInputElement | null>(null)
+const showRecurringDeleteOptions = ref(false)
+
+function handleDelete() {
+	showRecurringDeleteOptions.value = true
+}
+
+function deleteWithMode(mode: RecurringDeleteMode) {
+	showRecurringDeleteOptions.value = false
+	emit('delete', mode)
+}
 
 onMounted(() => {
 	const isMobile = window.matchMedia('(max-width: 768px)').matches
@@ -107,12 +118,35 @@ onMounted(() => {
 				</div>
 			</div>
 			<div class="edit-dialog-footer">
-				<button class="edit-delete-btn" @click="$emit('delete')">
+				<button class="edit-delete-btn" @click="isRecurring ? handleDelete() : $emit('delete')">
 					Delete
 				</button>
 				<NcButton type="primary" @click="$emit('save')">
 					Save
 				</NcButton>
+			</div>
+		</div>
+		<div v-if="showRecurringDeleteOptions" class="recurring-delete-overlay" @click.self="showRecurringDeleteOptions = false">
+			<div class="recurring-delete-dialog" @keydown.escape="showRecurringDeleteOptions = false">
+				<div class="recurring-delete-header">
+					<h3>Delete recurring task</h3>
+				</div>
+				<div class="recurring-delete-options">
+					<button class="recurring-delete-option" @click="deleteWithMode('this')">
+						This occurrence
+					</button>
+					<button class="recurring-delete-option" @click="deleteWithMode('this-and-future')">
+						This and following occurrences
+					</button>
+					<button class="recurring-delete-option" @click="deleteWithMode('all')">
+						All occurrences
+					</button>
+				</div>
+				<div class="recurring-delete-footer">
+					<button class="recurring-delete-cancel" @click="showRecurringDeleteOptions = false">
+						Cancel
+					</button>
+				</div>
 			</div>
 		</div>
 	</div>
@@ -316,6 +350,88 @@ onMounted(() => {
 
 .edit-delete-btn:hover {
 	background-color: rgba(200, 0, 0, 0.1);
+}
+
+.recurring-delete-overlay {
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	background-color: rgba(0, 0, 0, 0.5);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	z-index: 10000;
+}
+
+.recurring-delete-dialog {
+	background-color: var(--color-main-background);
+	border-radius: 12px;
+	width: 320px;
+	max-width: 90vw;
+	box-shadow: 0 4px 24px rgba(0, 0, 0, 0.2);
+	overflow: hidden;
+}
+
+.recurring-delete-header {
+	padding: 16px 20px;
+	border-bottom: 1px solid var(--color-border);
+}
+
+.recurring-delete-header h3 {
+	margin: 0;
+	font-size: 16px;
+	font-weight: 600;
+	color: var(--color-main-text);
+}
+
+.recurring-delete-options {
+	display: flex;
+	flex-direction: column;
+}
+
+.recurring-delete-option {
+	background: none;
+	border: none;
+	border-bottom: 1px solid var(--color-border);
+	cursor: pointer;
+	padding: 14px 20px;
+	font-size: 14px;
+	color: var(--color-main-text);
+	text-align: left;
+	font-family: inherit;
+}
+
+.recurring-delete-option:hover {
+	background-color: var(--color-background-hover);
+}
+
+.recurring-delete-option:last-child {
+	border-bottom: none;
+}
+
+.recurring-delete-footer {
+	padding: 12px 20px;
+	border-top: 1px solid var(--color-border);
+	display: flex;
+	justify-content: flex-end;
+}
+
+.recurring-delete-cancel {
+	background: none;
+	border: none;
+	cursor: pointer;
+	color: var(--color-text-maxcontrast);
+	font-size: 14px;
+	padding: 8px 16px;
+	border-radius: 6px;
+	font-family: inherit;
+}
+
+.recurring-delete-cancel:hover {
+	background-color: var(--color-background-hover);
+	color: var(--color-main-text);
 }
 
 @media (max-width: 768px) {

--- a/src/composables/useTaskEditing.ts
+++ b/src/composables/useTaskEditing.ts
@@ -1,6 +1,6 @@
 import { ref, nextTick } from 'vue'
 import type { Ref, ComputedRef } from 'vue'
-import type { Recurrence, TaskColor, Task, RecurringTaskDefinition, DayKey, WeekData, CustomColumn } from '../types'
+import type { Recurrence, TaskColor, Task, RecurringTaskDefinition, DayKey, WeekData, CustomColumn, RecurringDeleteMode } from '../types'
 import { ALL_KEYS } from '../types'
 import { getWeekDates, toDateStr } from '../utils/dateUtils'
 
@@ -156,35 +156,64 @@ export function useTaskEditing(
 		editingTask.value = null
 	}
 
-	function deleteEditingTask() {
+	function deleteEditingTask(mode?: RecurringDeleteMode) {
 		if (!editingTask.value) return
 		const { day, taskId } = editingTask.value
 		if (isCustomColumn(day)) {
 			deleteCustomTask(day, taskId)
 		} else {
 			const task = weekData.value.days[day as DayKey].find((t) => t.id === taskId)
-			if (task?.recurringSourceId) {
+			if (task?.recurringSourceId && mode) {
 				const sourceId = task.recurringSourceId
 				const dateStr = getTaskDate(day as DayKey)
 				const def = recurringTasks.value.find((d) => d.id === sourceId)
-				if (def) {
-					const prev = new Date(dateStr + 'T00:00:00')
-					prev.setDate(prev.getDate() - 1)
-					def.endDate = toDateStr(prev)
-				}
-				const dates = getWeekDates(currentYear.value, currentWeek.value)
-				for (let i = 0; i < ALL_KEYS.length; i++) {
-					const dStr = toDateStr(dates[i])
-					if (dStr >= dateStr) {
-						weekData.value.days[ALL_KEYS[i]] = weekData.value.days[ALL_KEYS[i]].filter(
+
+				if (mode === 'this') {
+					// Delete only this occurrence: add to exception dates
+					if (def) {
+						const exceptionDate = task.recurringOriginalDate || dateStr
+						if (!def.exceptionDates.includes(exceptionDate)) {
+							def.exceptionDates.push(exceptionDate)
+						}
+					}
+					weekData.value.days[day as DayKey] = weekData.value.days[day as DayKey].filter((t) => t.id !== taskId)
+					flushSaveTimeout()
+					flushCustomSaveTimeout()
+					saveCustomColumnsNow()
+					saveWeekNow()
+				} else if (mode === 'this-and-future') {
+					// Delete this and all future occurrences: set endDate to day before
+					if (def) {
+						const prev = new Date(dateStr + 'T00:00:00')
+						prev.setDate(prev.getDate() - 1)
+						def.endDate = toDateStr(prev)
+					}
+					const dates = getWeekDates(currentYear.value, currentWeek.value)
+					for (let i = 0; i < ALL_KEYS.length; i++) {
+						const dStr = toDateStr(dates[i])
+						if (dStr >= dateStr) {
+							weekData.value.days[ALL_KEYS[i]] = weekData.value.days[ALL_KEYS[i]].filter(
+								(t) => t.recurringSourceId !== sourceId,
+							)
+						}
+					}
+					flushSaveTimeout()
+					flushCustomSaveTimeout()
+					saveCustomColumnsNow()
+					saveWeekNow()
+				} else if (mode === 'all') {
+					// Delete all occurrences: remove definition and all instances
+					recurringTasks.value = recurringTasks.value.filter((d) => d.id !== sourceId)
+					for (const key of ALL_KEYS) {
+						weekData.value.days[key] = weekData.value.days[key].filter(
 							(t) => t.recurringSourceId !== sourceId,
 						)
 					}
+					flushSaveTimeout()
+					flushCustomSaveTimeout()
+					saveCustomColumnsNow()
+					saveWeekNow()
 				}
-				flushSaveTimeout()
-				flushCustomSaveTimeout()
-				saveCustomColumnsNow()
-				saveWeekNow()
 			} else {
 				weekData.value.days[day as DayKey] = weekData.value.days[day as DayKey].filter((t) => t.id !== taskId)
 				debouncedSave()

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,7 @@
 export type Recurrence = '' | 'daily' | 'weekly' | 'monthly'
 
+export type RecurringDeleteMode = 'this' | 'this-and-future' | 'all'
+
 export type TaskColor = '' | 'red' | 'orange' | 'yellow' | 'green' | 'blue' | 'purple'
 
 export const TASK_COLORS: { value: TaskColor; label: string; hex: string }[] = [


### PR DESCRIPTION
## Summary
This PR adds a dialog for users to select how they want to delete recurring tasks, with options to delete only the current occurrence, this and future occurrences, or all occurrences in the series.

## Key Changes
- **New type**: Added `RecurringDeleteMode` type with three modes: `'this'`, `'this-and-future'`, and `'all'`
- **EditDialog component**: 
  - Added `isRecurring` prop to detect if the task being edited is part of a recurring series
  - Implemented a modal dialog that appears when deleting a recurring task, allowing users to choose the deletion mode
  - Updated delete button to show the dialog for recurring tasks instead of immediately deleting
  - Added styling for the recurring delete dialog with overlay, options, and cancel button
- **useTaskEditing composable**:
  - Updated `deleteEditingTask()` to accept an optional `RecurringDeleteMode` parameter
  - Implemented three deletion strategies:
    - `'this'`: Adds the date to exception dates, removing only this occurrence
    - `'this-and-future'`: Sets the recurrence end date to the day before, removing this and all future occurrences
    - `'all'`: Removes the entire recurring task definition and all its instances
- **App.vue**:
  - Added `editingTaskIsRecurring` computed property to determine if the currently edited task is recurring
  - Passed the `isRecurring` prop to EditDialog
  - Updated delete event handler to pass the selected mode to `deleteEditingTask()`

## Implementation Details
- The delete dialog uses a fixed overlay with proper z-index layering and keyboard escape support
- Exception dates are properly tracked for individual occurrence deletions
- All three deletion modes properly clean up the UI state and trigger saves

https://claude.ai/code/session_01WfSbDKp99LDnVdBx6e2nGq