### PR TITLE
fix(release): validate app signature locally to catch signing drift

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,11 +37,16 @@ jobs:
   psalm:
     uses: ./.github/workflows/psalm-matrix.yml
 
+  test-app-signature:
+    uses: ./.github/workflows/test-app-signature.yml
+    # The validate-keys job declares `environment: Production` and pulls
+    # APP_PRIVATE_KEY directly from there, so no explicit secrets pass.
+
   # ─── Release ──────────────────────────────────────────────────────────
   # Only runs after ALL CI checks pass.
 
   release:
-    needs: [lint-info-xml, lint-eslint, lint-stylelint, lint-php, lint-php-cs, node-build, psalm]
+    needs: [lint-info-xml, lint-eslint, lint-stylelint, lint-php, lint-php-cs, node-build, psalm, test-app-signature]
     runs-on: ubuntu-latest
     environment: Production
     permissions:
@@ -136,44 +141,20 @@ jobs:
         run: |
           echo "$APP_PRIVATE_KEY" > /tmp/app.key
           curl -sf https://raw.githubusercontent.com/nextcloud/app-certificate-requests/master/weekplanner/weekplanner.crt > /tmp/app.crt
-          php <<'SIGN_EOF'
-          <?php
-          $appId = getenv('APP_ID');
-          $appPath = '/tmp/' . $appId;
-          $privateKey = openssl_pkey_get_private(file_get_contents('/tmp/app.key'));
-          if ($privateKey === false) {
-              fwrite(STDERR, "::error::Failed to load private key\n");
-              exit(1);
-          }
-          $certificate = file_get_contents('/tmp/app.crt');
-
-          $dir = new RecursiveDirectoryIterator($appPath, RecursiveDirectoryIterator::SKIP_DOTS);
-          $iterator = new RecursiveIteratorIterator($dir);
-
-          $hashes = [];
-          foreach ($iterator as $file) {
-              if ($file->isFile()) {
-                  $relativePath = substr($file->getPathname(), strlen($appPath) + 1);
-                  if ($relativePath === 'appinfo/signature.json') {
-                      continue;
-                  }
-                  $hashes[$relativePath] = hash_file('sha512', $file->getPathname());
-              }
-          }
-          ksort($hashes);
-
-          openssl_sign(json_encode($hashes), $signature, $privateKey, OPENSSL_ALGO_SHA512);
-
-          $result = [
-              'hashes' => $hashes,
-              'signature' => base64_encode($signature),
-              'certificate' => $certificate,
-          ];
-
-          file_put_contents("$appPath/appinfo/signature.json", json_encode($result, JSON_PRETTY_PRINT));
-          echo "Signed " . count($hashes) . " files\n";
-          SIGN_EOF
+          # sign-app.php aborts if the cert public key doesn't match the
+          # private key — that mismatch is the most likely cause of the
+          # "Signature could not get verified" integrity error reported
+          # against v1.8.1.
+          php tools/sign-app.php "/tmp/${APP_ID}" /tmp/app.key /tmp/app.crt
           rm -f /tmp/app.key /tmp/app.crt
+
+      - name: Verify signature locally (mirrors Nextcloud integrity check)
+        if: steps.signing.outputs.available == 'true'
+        run: |
+          # Runs the same checks as `occ integrity:check-app weekplanner`.
+          # If this fails the release is aborted before publishing, so users
+          # never see "Signature could not get verified" in the admin panel.
+          php tools/verify-app-signature.php "/tmp/${APP_ID}" --cn="${APP_ID}"
 
       - name: Create tarball
         run: |

--- a/.github/workflows/test-app-signature.yml
+++ b/.github/workflows/test-app-signature.yml
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: 2026 Sören Johanson
+# SPDX-License-Identifier: MIT
+
+# Two-layer guard for the app signing pipeline.
+#
+# 1. roundtrip — runs on every PR/push: exercises the sign + verify scripts
+#    with throwaway keys to catch logic regressions in tools/sign-app.php or
+#    tools/verify-app-signature.php. No secrets needed, safe for fork PRs.
+#
+# 2. validate-keys — runs whenever secrets are available (push to main,
+#    internal PRs, release): proves APP_PRIVATE_KEY still matches the
+#    published weekplanner.crt before the release pipeline tries to use it.
+#    Skips silently on fork PRs where the secret can't be exposed.
+#    This is the gate that would have caught the v1.8.1 drift.
+
+name: Test app signature
+
+on:
+  pull_request:
+    paths:
+      - 'tools/sign-app.php'
+      - 'tools/verify-app-signature.php'
+      - 'tools/test-app-signature.sh'
+      - '.github/workflows/test-app-signature.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'tools/sign-app.php'
+      - 'tools/verify-app-signature.php'
+      - 'tools/test-app-signature.sh'
+      - '.github/workflows/test-app-signature.yml'
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  roundtrip:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@cf4cade2721270509d5b1c766ab3549210a39a2a # v2.33.0
+        with:
+          php-version: '8.2'
+          extensions: openssl, json
+          coverage: none
+
+      - name: Run signing round-trip
+        run: bash tools/test-app-signature.sh
+
+  validate-keys:
+    runs-on: ubuntu-latest
+    # APP_PRIVATE_KEY is scoped to the Production environment (same as the
+    # release job). Without declaring it here the secret resolves to an
+    # empty string and the job skips itself.
+    environment: Production
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@cf4cade2721270509d5b1c766ab3549210a39a2a # v2.33.0
+        with:
+          php-version: '8.2'
+          extensions: openssl, json
+          coverage: none
+
+      - name: Validate APP_PRIVATE_KEY against published weekplanner.crt
+        env:
+          APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${APP_PRIVATE_KEY:-}" ]; then
+            # Fork PR or maintainer hasn't configured the secret yet.
+            # Don't fail the workflow — the roundtrip job already covered
+            # the logic, and release.yml has its own guard.
+            echo "::warning::APP_PRIVATE_KEY not available — skipping real-key validation."
+            exit 0
+          fi
+          echo "$APP_PRIVATE_KEY" > /tmp/app.key
+          # Fetch the same certificate release.yml would use at sign time.
+          curl -sf \
+            https://raw.githubusercontent.com/nextcloud/app-certificate-requests/master/weekplanner/weekplanner.crt \
+            > /tmp/app.crt
+          # Tiny fixture so sign-app.php has something to hash. The script
+          # exits non-zero if the cert public key doesn't match the private
+          # key — that's the actual check we care about here.
+          mkdir -p /tmp/wp-fixture/appinfo
+          echo '<?xml version="1.0"?><info><id>weekplanner</id></info>' \
+            > /tmp/wp-fixture/appinfo/info.xml
+          php tools/sign-app.php /tmp/wp-fixture /tmp/app.key /tmp/app.crt
+          # And re-verify, end-to-end, exactly like Nextcloud would.
+          php tools/verify-app-signature.php /tmp/wp-fixture --cn=weekplanner
+          rm -f /tmp/app.key /tmp/app.crt

--- a/tools/sign-app.php
+++ b/tools/sign-app.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * Sign a Nextcloud app directory.
+ *
+ * Produces <appPath>/appinfo/signature.json containing:
+ *   - hashes: { relativePath: sha512 } for every file except signature.json
+ *             (sorted alphabetically, mirroring Nextcloud's Checker)
+ *   - signature: base64(RSA-SHA512 PKCS#1 v1.5 over json_encode(hashes))
+ *   - certificate: the PEM cert for the app
+ *
+ * Usage:
+ *   php tools/sign-app.php <appPath> <privateKeyPath> <certificatePath>
+ *
+ * The hash/sign logic intentionally matches Nextcloud's
+ * lib/private/IntegrityCheck/Checker.php so verifyAppSignature() succeeds.
+ */
+
+declare(strict_types=1);
+
+if ($argc !== 4) {
+	fwrite(STDERR, "Usage: php sign-app.php <appPath> <privateKeyPath> <certificatePath>\n");
+	exit(1);
+}
+
+[$_, $appPath, $privateKeyPath, $certificatePath] = $argv;
+$appPath = rtrim($appPath, '/');
+
+if (!is_dir($appPath)) {
+	fwrite(STDERR, "::error::App path not found: $appPath\n");
+	exit(1);
+}
+
+$privateKey = openssl_pkey_get_private(file_get_contents($privateKeyPath));
+if ($privateKey === false) {
+	fwrite(STDERR, "::error::Failed to load private key: $privateKeyPath\n");
+	exit(1);
+}
+
+$certificate = file_get_contents($certificatePath);
+if ($certificate === false || trim($certificate) === '') {
+	fwrite(STDERR, "::error::Failed to read certificate: $certificatePath\n");
+	exit(1);
+}
+
+// Sanity: cert public key must match the signing private key, otherwise
+// the signature will fail Nextcloud's integrity check on install.
+$certPublicKey = openssl_pkey_get_public($certificate);
+if ($certPublicKey === false) {
+	fwrite(STDERR, "::error::Failed to extract public key from certificate\n");
+	exit(1);
+}
+$privDetails = openssl_pkey_get_details($privateKey);
+$pubDetails = openssl_pkey_get_details($certPublicKey);
+if (!$privDetails || !$pubDetails || $privDetails['key'] !== $pubDetails['key']) {
+	fwrite(STDERR, "::error::Certificate public key does not match the signing private key.\n");
+	fwrite(STDERR, "          Signatures produced now will fail Nextcloud integrity verification.\n");
+	exit(1);
+}
+
+$hashes = computeHashes($appPath);
+ksort($hashes);
+
+$signature = '';
+if (!openssl_sign(json_encode($hashes), $signature, $privateKey, OPENSSL_ALGO_SHA512)) {
+	fwrite(STDERR, "::error::openssl_sign failed\n");
+	exit(1);
+}
+
+$result = [
+	'hashes' => $hashes,
+	'signature' => base64_encode($signature),
+	'certificate' => $certificate,
+];
+
+$out = "$appPath/appinfo/signature.json";
+if (file_put_contents($out, json_encode($result, JSON_PRETTY_PRINT)) === false) {
+	fwrite(STDERR, "::error::Failed to write $out\n");
+	exit(1);
+}
+
+echo 'Signed ' . count($hashes) . " files into $out\n";
+
+/**
+ * Iterate the app directory and return [relativePath => sha512].
+ *
+ * Mirrors Nextcloud's Checker::generateHashes for app paths:
+ * skips only appinfo/signature.json (.htaccess and .user.ini exclusions
+ * apply to the server root, not to apps).
+ */
+function computeHashes(string $appPath): array {
+	$dir = new RecursiveDirectoryIterator($appPath, RecursiveDirectoryIterator::SKIP_DOTS);
+	$iterator = new RecursiveIteratorIterator($dir);
+
+	$hashes = [];
+	foreach ($iterator as $file) {
+		if (!$file->isFile()) {
+			continue;
+		}
+		$relativePath = ltrim(substr($file->getPathname(), strlen($appPath)), '/');
+		if ($relativePath === 'appinfo/signature.json') {
+			continue;
+		}
+		$hashes[$relativePath] = hash_file('sha512', $file->getPathname());
+	}
+	return $hashes;
+}

--- a/tools/test-app-signature.sh
+++ b/tools/test-app-signature.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# Round-trip test for tools/sign-app.php and tools/verify-app-signature.php.
+# Generates a throwaway RSA keypair + self-signed cert, signs a fixture app
+# directory, then asserts that:
+#   1. A clean signed app verifies.
+#   2. Modifying any file after signing breaks verification.
+#   3. Adding any file after signing breaks verification.
+#   4. A cert/key mismatch is rejected at signing time.
+#
+# This is the CI gate that would have caught the v1.8.1 signing bug.
+#
+# Exits 0 on success, non-zero on the first failed assertion.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+red() { printf '\033[31m%s\033[0m\n' "$*" >&2; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+
+# 1. Build a tiny fixture app.
+APP="$WORK/weekplanner"
+mkdir -p "$APP/appinfo" "$APP/lib" "$APP/js" "$APP/css"
+cat > "$APP/appinfo/info.xml" <<'EOF'
+<?xml version="1.0"?>
+<info><id>weekplanner</id><version>0.0.0</version></info>
+EOF
+echo '// fixture' > "$APP/lib/Bootstrap.php"
+echo '/* fixture */' > "$APP/js/main.js"
+echo '/* fixture */' > "$APP/css/main.css"
+
+# 2. Generate a throwaway key + self-signed cert with CN=weekplanner.
+openssl req -new -newkey rsa:2048 -nodes -x509 -days 1 \
+	-subj "/CN=weekplanner" \
+	-keyout "$WORK/app.key" -out "$WORK/app.crt" 2>/dev/null
+
+# 3. Happy path: sign + verify.
+php "$ROOT_DIR/tools/sign-app.php" "$APP" "$WORK/app.key" "$WORK/app.crt" >/dev/null
+php "$ROOT_DIR/tools/verify-app-signature.php" "$APP" --cn=weekplanner >/dev/null
+green "[ok] clean signature verifies"
+
+# 4. Tamper: modify a file → verify must fail.
+echo '// tampered' >> "$APP/js/main.js"
+if php "$ROOT_DIR/tools/verify-app-signature.php" "$APP" >/dev/null 2>&1; then
+	red "[fail] modified file did not break verification"
+	exit 1
+fi
+green "[ok] modified file breaks verification"
+
+# 5. Re-sign, then add an extra file → verify must fail.
+php "$ROOT_DIR/tools/sign-app.php" "$APP" "$WORK/app.key" "$WORK/app.crt" >/dev/null
+echo 'sneaky' > "$APP/lib/Sneaky.php"
+if php "$ROOT_DIR/tools/verify-app-signature.php" "$APP" >/dev/null 2>&1; then
+	red "[fail] extra file did not break verification"
+	exit 1
+fi
+green "[ok] extra file breaks verification"
+
+# 6. Cert/key mismatch must be rejected by sign-app (the cause of the v1.8.1 bug
+#    if APP_PRIVATE_KEY ever drifts from the published certificate).
+openssl req -new -newkey rsa:2048 -nodes -x509 -days 1 \
+	-subj "/CN=weekplanner" \
+	-keyout "$WORK/other.key" -out "$WORK/other.crt" 2>/dev/null
+rm -rf "$APP"
+mkdir -p "$APP/appinfo"
+echo '<?xml version="1.0"?><info><id>weekplanner</id></info>' > "$APP/appinfo/info.xml"
+if php "$ROOT_DIR/tools/sign-app.php" "$APP" "$WORK/app.key" "$WORK/other.crt" >/dev/null 2>&1; then
+	red "[fail] cert/key mismatch was not rejected"
+	exit 1
+fi
+green "[ok] cert/key mismatch is rejected"
+
+green "All signature round-trip checks passed."

--- a/tools/verify-app-signature.php
+++ b/tools/verify-app-signature.php
@@ -1,0 +1,181 @@
+<?php
+
+/**
+ * Locally verify a Nextcloud app's signature.json the same way the
+ * server does on install / `occ integrity:check-app`.
+ *
+ * Mirrors lib/private/IntegrityCheck/Checker::verify() for an app path:
+ *   1. Load signature.json, ksort hashes, decode signature.
+ *   2. Verify RSA-SHA512 PKCS#1 v1.5 signature over json_encode(hashes)
+ *      using the public key embedded in the bundled certificate.
+ *   3. Re-hash the app directory and report any missing / extra / changed
+ *      files vs the stored hashes.
+ *
+ * Optional flags:
+ *   --root-ca=<path>  Verify the bundled certificate against this CA cert
+ *                     (Nextcloud's resources/codesigning/root.crt). Skipped
+ *                     when not provided so contributors without the CA can
+ *                     still validate hash + signature integrity locally.
+ *   --cn=<appId>      Assert the certificate CN matches this app id.
+ *
+ * Usage:
+ *   php tools/verify-app-signature.php <appPath> [--root-ca=<path>] [--cn=<appId>]
+ *
+ * Exit codes:
+ *   0 — signature verified
+ *   1 — verification failed (with a diagnostic on stderr)
+ */
+
+declare(strict_types=1);
+
+if ($argc < 2) {
+	fwrite(STDERR, "Usage: php verify-app-signature.php <appPath> [--root-ca=<path>] [--cn=<appId>]\n");
+	exit(1);
+}
+
+$appPath = rtrim($argv[1], '/');
+$rootCaPath = null;
+$expectedCN = null;
+for ($i = 2; $i < $argc; $i++) {
+	if (str_starts_with($argv[$i], '--root-ca=')) {
+		$rootCaPath = substr($argv[$i], strlen('--root-ca='));
+	} elseif (str_starts_with($argv[$i], '--cn=')) {
+		$expectedCN = substr($argv[$i], strlen('--cn='));
+	} else {
+		fwrite(STDERR, "::error::Unknown argument: {$argv[$i]}\n");
+		exit(1);
+	}
+}
+
+$signaturePath = "$appPath/appinfo/signature.json";
+if (!file_exists($signaturePath)) {
+	fwrite(STDERR, "::error::signature.json not found at $signaturePath\n");
+	exit(1);
+}
+
+$signatureData = json_decode(file_get_contents($signaturePath), true);
+if (!is_array($signatureData)
+	|| !isset($signatureData['hashes'], $signatureData['signature'], $signatureData['certificate'])) {
+	fwrite(STDERR, "::error::signature.json is malformed (missing hashes/signature/certificate)\n");
+	exit(1);
+}
+
+// 1. Hashes & signature — sort like Nextcloud does before verifying.
+$expectedHashes = $signatureData['hashes'];
+ksort($expectedHashes);
+$signature = base64_decode($signatureData['signature'], true);
+if ($signature === false) {
+	fwrite(STDERR, "::error::signature.json signature field is not valid base64\n");
+	exit(1);
+}
+$certificate = $signatureData['certificate'];
+
+// 2. Optional CA chain check.
+if ($rootCaPath !== null) {
+	$rootCa = @file_get_contents($rootCaPath);
+	if ($rootCa === false) {
+		fwrite(STDERR, "::error::Failed to read root CA: $rootCaPath\n");
+		exit(1);
+	}
+	// openssl_x509_verify isn't a chain verifier, so use openssl_pkey_get_public on the CA
+	// and call openssl verify equivalent via a tempfile + `openssl verify` is heavy.
+	// We instead extract the CA's public key, then manually verify via openssl_x509_parse
+	// for sanity. Full chain validation is the server's job; we only catch obvious mismatches.
+	$caParsed = openssl_x509_parse($rootCa);
+	$certParsed = openssl_x509_parse($certificate);
+	if ($caParsed === false || $certParsed === false) {
+		fwrite(STDERR, "::error::Failed to parse certificate(s)\n");
+		exit(1);
+	}
+	if (($certParsed['issuer']['CN'] ?? null) !== ($caParsed['subject']['CN'] ?? null)) {
+		fwrite(STDERR, sprintf(
+			"::error::Certificate issuer CN (%s) does not match root CA CN (%s)\n",
+			$certParsed['issuer']['CN'] ?? '?',
+			$caParsed['subject']['CN'] ?? '?',
+		));
+		exit(1);
+	}
+}
+
+// 3. Optional CN check.
+if ($expectedCN !== null) {
+	$certParsed = openssl_x509_parse($certificate);
+	$cn = $certParsed['subject']['CN'] ?? null;
+	if ($cn !== $expectedCN) {
+		fwrite(STDERR, sprintf(
+			"::error::Certificate CN (%s) does not match expected app id (%s)\n",
+			$cn ?? '?',
+			$expectedCN,
+		));
+		exit(1);
+	}
+}
+
+// 4. Verify the RSA signature over json_encode(expectedHashes).
+$publicKey = openssl_pkey_get_public($certificate);
+if ($publicKey === false) {
+	fwrite(STDERR, "::error::Failed to extract public key from bundled certificate\n");
+	exit(1);
+}
+$verifyResult = openssl_verify(json_encode($expectedHashes), $signature, $publicKey, OPENSSL_ALGO_SHA512);
+if ($verifyResult !== 1) {
+	fwrite(STDERR, "::error::Signature could not get verified (openssl_verify returned $verifyResult).\n");
+	fwrite(STDERR, "         This is the same error Nextcloud's integrity check would raise.\n");
+	exit(1);
+}
+
+// 5. Re-hash the disk and compare to stored hashes.
+$currentHashes = computeHashes($appPath);
+ksort($currentHashes);
+
+$missing = array_diff_key($expectedHashes, $currentHashes);
+$extra = array_diff_key($currentHashes, $expectedHashes);
+$changed = [];
+foreach ($expectedHashes as $path => $hash) {
+	if (isset($currentHashes[$path]) && $currentHashes[$path] !== $hash) {
+		$changed[] = $path;
+	}
+}
+
+if ($missing || $extra || $changed) {
+	fwrite(STDERR, "::error::Hash mismatch — Nextcloud's integrity check would fail.\n");
+	if ($missing) {
+		fwrite(STDERR, 'Missing on disk (' . count($missing) . "):\n");
+		foreach (array_keys($missing) as $f) {
+			fwrite(STDERR, "  - $f\n");
+		}
+	}
+	if ($extra) {
+		fwrite(STDERR, 'Unsigned files on disk (' . count($extra) . "):\n");
+		foreach (array_keys($extra) as $f) {
+			fwrite(STDERR, "  - $f\n");
+		}
+	}
+	if ($changed) {
+		fwrite(STDERR, 'Modified after signing (' . count($changed) . "):\n");
+		foreach ($changed as $f) {
+			fwrite(STDERR, "  - $f\n");
+		}
+	}
+	exit(1);
+}
+
+echo 'Signature verified for ' . count($expectedHashes) . " files in $appPath\n";
+
+function computeHashes(string $appPath): array {
+	$dir = new RecursiveDirectoryIterator($appPath, RecursiveDirectoryIterator::SKIP_DOTS);
+	$iterator = new RecursiveIteratorIterator($dir);
+
+	$hashes = [];
+	foreach ($iterator as $file) {
+		if (!$file->isFile()) {
+			continue;
+		}
+		$relativePath = ltrim(substr($file->getPathname(), strlen($appPath)), '/');
+		if ($relativePath === 'appinfo/signature.json') {
+			continue;
+		}
+		$hashes[$relativePath] = hash_file('sha512', $file->getPathname());
+	}
+	return $hashes;
+}


### PR DESCRIPTION
Reported against v1.8.1: Nextcloud's admin integrity check fails with 'Signature could not get verified' even though appinfo/signature.json is present and complete. The release pipeline produced a tarball whose signature can never satisfy occ integrity:check-app, and nothing in CI caught it before publishing to the App Store.

Most likely cause: drift between APP_PRIVATE_KEY (GitHub secret) and the published certificate at app-certificate-requests/master/weekplanner/ weekplanner.crt. The previous inline signing PHP did no key/cert sanity check, so a mismatched pair silently produced a malformed release.