### PR TITLE
fix(compat): declare Nextcloud 34 support

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -20,7 +20,7 @@ A simple weekly planner inspired by [Tweek](https://tweek.so), living right insi
 - **📱 Mobile friendly:** The interface works well on smaller screens so you can plan on the go.
 - **🧩 Nextcloud native:** Fully integrated into the Nextcloud navigation — no external accounts, no third-party sync, no tracking.
   ]]></description>
-  <version>1.9.1</version>
+  <version>1.9.2</version>
   <licence>AGPL-3.0-or-later</licence>
 
   <author mail="soeren@soeren.codes" homepage="https://www.soeren.codes">Sören Johanson</author>
@@ -36,7 +36,7 @@ A simple weekly planner inspired by [Tweek](https://tweek.so), living right insi
   <screenshot>https://raw.githubusercontent.com/sorenjohanson/weekplanner-nextcloud/main/img/weekplanner_promo_image.png</screenshot>
 
   <dependencies>
-    <nextcloud min-version="31" max-version="33"/>
+    <nextcloud min-version="31" max-version="34"/>
   </dependencies>
 
   <navigations>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weekplanner",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Audit confirmed no usage of the front-end APIs (OC.Dialogs.fileexists, OC.Notifications, OC.Apps, OC.*menu*, .live-relative-timestamp, snapper, jQuery, jQuery UI, Backbone, OC.Files.Client, Handlebars) or back-end APIs (Share_Backend*, the deprecated EmptyContentSecurityPolicy methods, IManager::registerResourceProvider, IManager::registerNotifier, Util::recursiveArraySearch, Strict*ContentSecurityPolicy) removed in Nextcloud 34. Bump max-version to 34 and patch version to 1.9.2.