### PR TITLE
feat(edit-dialog): add Move to picker for cross-day task moves

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -20,7 +20,7 @@ A simple weekly planner inspired by [Tweek](https://tweek.so), living right insi
 - **📱 Mobile friendly:** The interface works well on smaller screens so you can plan on the go.
 - **🧩 Nextcloud native:** Fully integrated into the Nextcloud navigation — no external accounts, no third-party sync, no tracking.
   ]]></description>
-  <version>1.9.3</version>
+  <version>1.10.0</version>
   <licence>AGPL-3.0-or-later</licence>
 
   <author mail="soeren@soeren.codes" homepage="https://www.soeren.codes">Sören Johanson</author>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weekplanner",
-  "version": "1.9.3",
+  "version": "1.10.0",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
-import { ref, onMounted, onUnmounted, watch } from 'vue'
+import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 import NcAppContent from '@nextcloud/vue/components/NcAppContent'
 import NcContent from '@nextcloud/vue/components/NcContent'
 import NcButton from '@nextcloud/vue/components/NcButton'
 import type { RecurringTaskDefinition, WeekData } from './types'
-import { WEEKDAY_KEYS, WEEKEND_KEYS, DAY_LABELS } from './types'
+import { WEEKDAY_KEYS, WEEKEND_KEYS, ALL_KEYS, DAY_LABELS } from './types'
 import TaskList from './components/TaskList.vue'
 import EditDialog from './components/EditDialog.vue'
 import { emptyWeek } from './utils/weekData'
@@ -41,7 +41,7 @@ const recurring = useRecurringTasks(
 
 const {
 	editingTask, editingTaskIsRecurring, editTitle, editNotes, editRecurrence, editColor,
-	newTasks, openEdit, saveEdit, deleteEditingTask, addTask, toggleDone,
+	newTasks, openEdit, saveEdit, deleteEditingTask, addTask, toggleDone, moveEditingTask,
 } = useTaskEditing({
 	currentYear,
 	currentWeek,
@@ -57,7 +57,20 @@ const {
 	flushCustomSaveTimeout: columns.flushCustomSaveTimeout,
 	deleteCustomTask: columns.deleteCustomTask,
 	materializeRecurringTasks: recurring.materializeRecurringTasks,
+	handleDragChange: recurring.handleDragChange,
 })
+
+const moveDayOptions = computed(() => ALL_KEYS.map((key) => ({
+	key,
+	label: DAY_LABELS[key],
+	date: formatDate(key),
+	isToday: isToday(key),
+})))
+
+const moveColumnOptions = computed(() => customColumns.value.map((c) => ({
+	id: c.id,
+	title: c.title,
+})))
 
 const polling = usePolling({
 	currentYear,
@@ -215,12 +228,16 @@ onUnmounted(() => {
 					:recurrence="editRecurrence"
 					:color="editColor"
 					:is-recurring="editingTaskIsRecurring"
+					:current-location="editingTask.day"
+					:move-day-options="moveDayOptions"
+					:move-column-options="moveColumnOptions"
 					@update:title="editTitle = $event"
 					@update:notes="editNotes = $event"
 					@update:recurrence="editRecurrence = $event"
 					@update:color="editColor = $event"
 					@save="saveEdit"
-					@delete="deleteEditingTask($event)" />
+					@delete="deleteEditingTask($event)"
+					@move="moveEditingTask($event)" />
 			</div>
 		</NcAppContent>
 	</NcContent>

--- a/src/components/EditDialog.vue
+++ b/src/components/EditDialog.vue
@@ -1,8 +1,20 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import NcButton from '@nextcloud/vue/components/NcButton'
-import type { Recurrence, TaskColor, RecurringDeleteMode } from '../types'
+import type { DayKey, Recurrence, TaskColor, RecurringDeleteMode } from '../types'
 import { TASK_COLORS } from '../types'
+
+export interface MoveDayOption {
+	key: DayKey
+	label: string
+	date: string
+	isToday: boolean
+}
+
+export interface MoveColumnOption {
+	id: string
+	title: string
+}
 
 defineProps<{
 	title: string
@@ -10,6 +22,9 @@ defineProps<{
 	recurrence: Recurrence
 	color: TaskColor
 	isRecurring: boolean
+	currentLocation: DayKey | string
+	moveDayOptions: MoveDayOption[]
+	moveColumnOptions: MoveColumnOption[]
 }>()
 
 const emit = defineEmits<{
@@ -19,6 +34,7 @@ const emit = defineEmits<{
 	'update:color': [value: TaskColor]
 	save: []
 	delete: [mode?: RecurringDeleteMode]
+	move: [target: DayKey | string]
 }>()
 
 const titleInput = ref<HTMLInputElement | null>(null)
@@ -115,6 +131,32 @@ onMounted(() => {
 						:style="{ backgroundColor: c.hex }"
 						:title="c.label"
 						@click="$emit('update:color', c.value)" />
+				</div>
+				<label class="edit-label edit-label-move">Move to</label>
+				<div class="edit-move-row">
+					<button
+						v-for="d in moveDayOptions"
+						:key="d.key"
+						type="button"
+						class="edit-move-chip"
+						:class="{ current: currentLocation === d.key, today: d.isToday }"
+						:disabled="currentLocation === d.key"
+						:title="d.date"
+						@click="emit('move', d.key)">
+						{{ d.label }}
+					</button>
+				</div>
+				<div v-if="moveColumnOptions.length" class="edit-move-row edit-move-row-columns">
+					<button
+						v-for="col in moveColumnOptions"
+						:key="col.id"
+						type="button"
+						class="edit-move-chip edit-move-chip-column"
+						:class="{ current: currentLocation === col.id }"
+						:disabled="currentLocation === col.id"
+						@click="emit('move', col.id)">
+						{{ col.title || 'Untitled column' }}
+					</button>
 				</div>
 			</div>
 			<div class="edit-dialog-footer">
@@ -294,6 +336,59 @@ onMounted(() => {
 .edit-color-none {
 	background-color: var(--color-main-background);
 	color: var(--color-text-maxcontrast);
+}
+
+.edit-label-move {
+	margin-top: 16px;
+}
+
+.edit-move-row {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px;
+}
+
+.edit-move-row-columns {
+	margin-top: 6px;
+}
+
+.edit-move-chip {
+	flex: 0 1 auto;
+	padding: 6px 10px;
+	border: 1px solid var(--color-border-dark);
+	border-radius: 999px;
+	background-color: var(--color-main-background);
+	color: var(--color-main-text);
+	font-size: 12px;
+	font-family: inherit;
+	cursor: pointer;
+	white-space: nowrap;
+	transition: background-color 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.edit-move-chip.current,
+.edit-move-chip:disabled {
+	background-color: var(--color-background-dark);
+	color: var(--color-text-maxcontrast);
+	cursor: default;
+	border-color: var(--color-border);
+}
+
+.edit-move-chip:hover:not(:disabled) {
+	border-color: var(--color-primary-element);
+	color: var(--color-primary-element);
+}
+
+.edit-move-chip.today:not(.current) {
+	border-color: var(--color-primary-element);
+	color: var(--color-primary-element);
+	font-weight: 600;
+}
+
+.edit-move-chip-column {
+	max-width: 160px;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .edit-dialog-footer {

--- a/src/composables/__tests__/useTaskEditing.test.ts
+++ b/src/composables/__tests__/useTaskEditing.test.ts
@@ -27,6 +27,7 @@ function setup(options: {
 	const flushCustomSaveTimeout = vi.fn()
 	const deleteCustomTask = vi.fn()
 	const materializeRecurringTasks = vi.fn()
+	const handleDragChange = vi.fn(() => false)
 
 	const editing = useTaskEditing({
 		currentYear,
@@ -43,6 +44,7 @@ function setup(options: {
 		flushCustomSaveTimeout,
 		deleteCustomTask,
 		materializeRecurringTasks,
+		handleDragChange,
 	})
 
 	return {
@@ -58,6 +60,7 @@ function setup(options: {
 		flushCustomSaveTimeout,
 		deleteCustomTask,
 		materializeRecurringTasks,
+		handleDragChange,
 	}
 }
 
@@ -439,6 +442,165 @@ describe('useTaskEditing', () => {
 
 			expect(deleteCustomTask).toHaveBeenCalledWith('custom_1', 't1')
 			expect(editingTask.value).toBeNull()
+		})
+	})
+
+	describe('moveEditingTask', () => {
+		it('moves a non-recurring task between days', () => {
+			const week = emptyWeek()
+			const task: Task = { id: 't1', title: 'Meeting', done: false, notes: '', recurrence: '', color: '' }
+			week.days.monday.push(task)
+			const {
+				openEdit, moveEditingTask, weekData, editingTask,
+				debouncedSave, debouncedSaveCustomColumns, materializeRecurringTasks,
+			} = setup({ weekOverride: week })
+
+			openEdit('monday', task)
+			moveEditingTask('sunday')
+
+			expect(weekData.value.days.monday).toHaveLength(0)
+			expect(weekData.value.days.sunday).toHaveLength(1)
+			expect(weekData.value.days.sunday[0].id).toBe('t1')
+			expect(editingTask.value).toBeNull()
+			expect(debouncedSave).toHaveBeenCalled()
+			expect(debouncedSaveCustomColumns).toHaveBeenCalled()
+			expect(materializeRecurringTasks).toHaveBeenCalled()
+		})
+
+		it('moves a task from a day to a custom column', () => {
+			const week = emptyWeek()
+			const task: Task = { id: 't1', title: 'Idea', done: false, notes: '', recurrence: '', color: '' }
+			week.days.tuesday.push(task)
+			const columns: CustomColumn[] = [{ id: 'custom_1', title: 'Someday', tasks: [] }]
+			const { openEdit, moveEditingTask, weekData, customColumns } = setup({ weekOverride: week, columns })
+
+			openEdit('tuesday', task)
+			moveEditingTask('custom_1')
+
+			expect(weekData.value.days.tuesday).toHaveLength(0)
+			expect(customColumns.value[0].tasks).toHaveLength(1)
+			expect(customColumns.value[0].tasks[0].id).toBe('t1')
+		})
+
+		it('moves a task from a custom column to a day', () => {
+			const week = emptyWeek()
+			const columns: CustomColumn[] = [{
+				id: 'custom_1',
+				title: 'Someday',
+				tasks: [{ id: 't1', title: 'Follow up', done: false, notes: '', recurrence: '', color: '' }],
+			}]
+			const { openEdit, moveEditingTask, weekData, customColumns } = setup({ weekOverride: week, columns })
+
+			openEdit('custom_1', columns[0].tasks[0])
+			moveEditingTask('thursday')
+
+			expect(customColumns.value[0].tasks).toHaveLength(0)
+			expect(weekData.value.days.thursday).toHaveLength(1)
+			expect(weekData.value.days.thursday[0].id).toBe('t1')
+		})
+
+		it('updates the recurring definition anchor when moving a recurring task day → day', () => {
+			const defId = 'def-1'
+			const week = emptyWeek()
+			const task: Task = {
+				id: 't1',
+				title: 'Standup',
+				done: false,
+				notes: '',
+				recurrence: 'weekly',
+				color: '',
+				recurringSourceId: defId,
+				recurringOriginalDate: '2026-03-16',
+			}
+			week.days.monday.push(task)
+			const defs: RecurringTaskDefinition[] = [{
+				id: defId,
+				title: 'Standup',
+				notes: '',
+				recurrence: 'weekly',
+				startDate: '2026-03-02',
+				endDate: '',
+				dayOfWeek: 0,
+				dayOfMonth: 2,
+				exceptionDates: ['2026-02-23'],
+			}]
+			const { openEdit, moveEditingTask, weekData, recurringTasks } = setup({
+				weekOverride: week, recurringDefs: defs,
+			})
+
+			openEdit('monday', task)
+			moveEditingTask('sunday')
+
+			// Week 12 of 2026 starts on Monday 2026-03-16, so Sunday is 2026-03-22
+			expect(recurringTasks.value[0].startDate).toBe('2026-03-22')
+			expect(recurringTasks.value[0].dayOfWeek).toBe(6)
+			expect(recurringTasks.value[0].dayOfMonth).toBe(22)
+			// Stale exception before new startDate is pruned
+			expect(recurringTasks.value[0].exceptionDates).toEqual([])
+			expect(weekData.value.days.monday).toHaveLength(0)
+			expect(weekData.value.days.sunday).toHaveLength(1)
+			expect(weekData.value.days.sunday[0].recurringOriginalDate).toBe('2026-03-22')
+		})
+
+		it('is a no-op when target equals source', () => {
+			const week = emptyWeek()
+			const task: Task = { id: 't1', title: 'Stay', done: false, notes: '', recurrence: '', color: '' }
+			week.days.monday.push(task)
+			const { openEdit, moveEditingTask, weekData, editingTask, debouncedSave } = setup({ weekOverride: week })
+
+			openEdit('monday', task)
+			moveEditingTask('monday')
+
+			expect(weekData.value.days.monday).toHaveLength(1)
+			expect(editingTask.value).toBeNull()
+			expect(debouncedSave).not.toHaveBeenCalled()
+		})
+
+		it('drops the moved recurring instance if the target day already has one for the same definition', () => {
+			const defId = 'def-1'
+			const week = emptyWeek()
+			const monTask: Task = {
+				id: 't1',
+				title: 'Daily',
+				done: false,
+				notes: '',
+				recurrence: 'daily',
+				color: '',
+				recurringSourceId: defId,
+				recurringOriginalDate: '2026-03-16',
+			}
+			const sunTask: Task = {
+				id: 't2',
+				title: 'Daily',
+				done: false,
+				notes: '',
+				recurrence: 'daily',
+				color: '',
+				recurringSourceId: defId,
+				recurringOriginalDate: '2026-03-22',
+			}
+			week.days.monday.push(monTask)
+			week.days.sunday.push(sunTask)
+			const defs: RecurringTaskDefinition[] = [{
+				id: defId,
+				title: 'Daily',
+				notes: '',
+				recurrence: 'daily',
+				startDate: '2026-03-01',
+				endDate: '',
+				dayOfWeek: 0,
+				dayOfMonth: 1,
+				exceptionDates: [],
+			}]
+			const { openEdit, moveEditingTask, weekData } = setup({ weekOverride: week, recurringDefs: defs })
+
+			openEdit('monday', monTask)
+			moveEditingTask('sunday')
+
+			expect(weekData.value.days.monday).toHaveLength(0)
+			// Sunday keeps the original instance (no duplication)
+			expect(weekData.value.days.sunday).toHaveLength(1)
+			expect(weekData.value.days.sunday[0].id).toBe('t2')
 		})
 	})
 })

--- a/src/composables/useTaskEditing.ts
+++ b/src/composables/useTaskEditing.ts
@@ -19,6 +19,7 @@ export interface TaskEditingDeps {
 	flushCustomSaveTimeout: () => void
 	deleteCustomTask: (columnId: string, taskId: string) => void
 	materializeRecurringTasks: () => void
+	handleDragChange: () => boolean
 }
 
 export function useTaskEditing(deps: TaskEditingDeps) {
@@ -26,6 +27,7 @@ export function useTaskEditing(deps: TaskEditingDeps) {
 		currentYear, currentWeek, weekData, weekDates, recurringTasks, customColumns,
 		debouncedSave, debouncedSaveCustomColumns, saveWeekNow, saveCustomColumnsNow,
 		flushSaveTimeout, flushCustomSaveTimeout, deleteCustomTask, materializeRecurringTasks,
+		handleDragChange,
 	} = deps
 	const editingTask = ref<{ day: DayKey | string; taskId: string } | null>(null)
 	const editTitle = ref('')
@@ -252,6 +254,82 @@ export function useTaskEditing(deps: TaskEditingDeps) {
 		}
 	}
 
+	// Picker-driven move from the edit dialog.
+	//
+	// For a recurring task moved between two day slots we intentionally diverge
+	// from drag semantics: drag adds an exception so future weeks keep the old
+	// pattern, but picker users explicitly chose "Sunday" — they expect the
+	// recurrence to follow. So we update the definition's startDate / dayOfWeek
+	// / dayOfMonth and drop now-stale exceptions before startDate.
+	//
+	// All other paths (non-recurring, or recurring involving a custom column)
+	// reuse handleDragChange so cross-list bookkeeping (originalDate, exception
+	// dates for moved instances) stays consistent with the drag flow.
+	function moveEditingTask(target: DayKey | string) {
+		if (!editingTask.value) return
+		const { day: sourceDay, taskId } = editingTask.value
+		if (target === sourceDay) {
+			editingTask.value = null
+			return
+		}
+
+		let task: Task | undefined
+		if (isCustomColumn(sourceDay)) {
+			const col = customColumns.value.find((c) => c.id === sourceDay)
+			if (col) {
+				const idx = col.tasks.findIndex((t) => t.id === taskId)
+				if (idx !== -1) task = col.tasks.splice(idx, 1)[0]
+			}
+		} else {
+			const arr = weekData.value.days[sourceDay as DayKey]
+			const idx = arr.findIndex((t) => t.id === taskId)
+			if (idx !== -1) task = arr.splice(idx, 1)[0]
+		}
+		if (!task) {
+			editingTask.value = null
+			return
+		}
+
+		const sourceIsDay = !isCustomColumn(sourceDay)
+		const targetIsDay = !isCustomColumn(target)
+		const isRecurringDayToDay = !!task.recurringSourceId && sourceIsDay && targetIsDay
+
+		if (isRecurringDayToDay) {
+			const def = recurringTasks.value.find((d) => d.id === task!.recurringSourceId)
+			if (def) {
+				const targetIdx = ALL_KEYS.indexOf(target as DayKey)
+				const targetDateStr = toDateStr(weekDates.value[targetIdx])
+				const targetDate = weekDates.value[targetIdx]
+				def.startDate = targetDateStr
+				def.dayOfWeek = targetIdx
+				def.dayOfMonth = targetDate.getDate()
+				def.exceptionDates = def.exceptionDates.filter((d) => d >= targetDateStr)
+				task.recurringOriginalDate = targetDateStr
+			}
+		}
+
+		if (targetIsDay) {
+			const targetArr = weekData.value.days[target as DayKey]
+			const duplicate = task.recurringSourceId
+				? targetArr.find((t) => t.recurringSourceId === task!.recurringSourceId)
+				: undefined
+			if (!duplicate) {
+				targetArr.push(task)
+			}
+		} else {
+			const col = customColumns.value.find((c) => c.id === target)
+			if (col) col.tasks.push(task)
+		}
+
+		if (!isRecurringDayToDay) {
+			handleDragChange()
+		}
+		materializeRecurringTasks()
+		debouncedSave()
+		debouncedSaveCustomColumns()
+		editingTask.value = null
+	}
+
 	const editingTaskIsRecurring = computed(() => {
 		if (!editingTask.value) return false
 		const { day, taskId } = editingTask.value
@@ -278,5 +356,6 @@ export function useTaskEditing(deps: TaskEditingDeps) {
 		deleteEditingTask,
 		addTask,
 		toggleDone,
+		moveEditingTask,
 	}
 }


### PR DESCRIPTION
Tapping a task already opens the edit dialog; this adds a Move to row of chips for each weekday and custom column so users can reposition a task in one tap instead of dragging and holding while the page scrolls. Especially helpful on mobile where columns stack vertically and a Monday-to-Sunday drag spans several screens.

For recurring tasks moved between two day slots, the picker updates the recurring definition's anchor (startDate, dayOfWeek, dayOfMonth) so the recurrence follows the user's choice. This diverges from drag, which adds an exception and keeps the original pattern. All other paths (non-recurring, anything involving a custom column) reuse the existing handleDragChange flow so cross-list bookkeeping is unchanged.