### PR TITLE
fix(calendar): respect user's first day of week preference

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -20,7 +20,7 @@ A simple weekly planner inspired by [Tweek](https://tweek.so), living right insi
 - **📱 Mobile friendly:** The interface works well on smaller screens so you can plan on the go.
 - **🧩 Nextcloud native:** Fully integrated into the Nextcloud navigation — no external accounts, no third-party sync, no tracking.
   ]]></description>
-  <version>1.12.0</version>
+  <version>1.12.1</version>
   <licence>AGPL-3.0-or-later</licence>
 
   <author mail="soeren@soeren.codes" homepage="https://www.soeren.codes">Sören Johanson</author>

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -11,19 +11,77 @@ use OCP\AppFramework\Http\Attribute\NoAdminRequired;
 use OCP\AppFramework\Http\Attribute\NoCSRFRequired;
 use OCP\AppFramework\Http\Attribute\OpenAPI;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Services\IInitialState;
+use OCP\IConfig;
+use OCP\IRequest;
+use OCP\IUserSession;
 
 /**
  * @psalm-suppress UnusedClass
  */
 class PageController extends Controller {
+	public function __construct(
+		IRequest $request,
+		private IInitialState $initialState,
+		private IConfig $config,
+		private IUserSession $userSession,
+	) {
+		parent::__construct(Application::APP_ID, $request);
+	}
+
 	#[NoCSRFRequired]
 	#[NoAdminRequired]
 	#[OpenAPI(OpenAPI::SCOPE_IGNORE)]
 	#[FrontpageRoute(verb: 'GET', url: '/')]
 	public function index(): TemplateResponse {
+		$this->initialState->provideInitialState(
+			'firstDayOfWeek',
+			$this->resolveFirstDayOfWeek(),
+		);
+
 		return new TemplateResponse(
 			Application::APP_ID,
 			'index',
 		);
+	}
+
+	/**
+	 * Resolve the user's preferred first day of week as 0..6 where 0=Sunday and 6=Saturday.
+	 *
+	 * Nextcloud's "Personal settings > Region & language > First day of week" stores
+	 * the value under `core.first_day_of_week`. We honour that, then fall back to a
+	 * weekplanner-specific override (set via occ for environments where the personal
+	 * setting isn't available), then Monday (ISO 8601 default).
+	 *
+	 * IConfig::getUserValue is marked deprecated in newer OCP versions in favour of
+	 * `OCP\Config\IUserConfig`, but that interface didn't exist in NC 31 (it was at
+	 * `NCU\Config\IUserConfig`, marked experimental, and gets deprecated again once
+	 * promoted). Until min-version moves past the experimental NCU interface, the
+	 * stable IConfig method is the only API that works across the full 31-34 matrix.
+	 *
+	 * @psalm-suppress DeprecatedMethod
+	 */
+	private function resolveFirstDayOfWeek(): int {
+		$user = $this->userSession->getUser();
+		if ($user === null) {
+			return 1;
+		}
+
+		$uid = $user->getUID();
+		$candidates = [
+			['core', 'first_day_of_week'],
+			[Application::APP_ID, 'firstDayOfWeek'],
+		];
+		foreach ($candidates as [$app, $key]) {
+			$value = $this->config->getUserValue($uid, $app, $key, '');
+			if ($value === '' || !is_numeric($value)) {
+				continue;
+			}
+			$intValue = (int)$value;
+			if ($intValue >= 0 && $intValue <= 6) {
+				return $intValue;
+			}
+		}
+		return 1;
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weekplanner",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "license": "AGPL-3.0-or-later",
   "type": "module",
   "scripts": {
@@ -18,6 +18,7 @@
   "dependencies": {
     "@nextcloud/axios": "^2.6.0",
     "@nextcloud/capabilities": "^1.2.1",
+    "@nextcloud/initial-state": "^3.0.0",
     "@nextcloud/notify_push": "^1.4.0",
     "@nextcloud/router": "^3.1.0",
     "@nextcloud/vue": "^9.8.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@nextcloud/capabilities':
         specifier: ^1.2.1
         version: 1.2.1
+      '@nextcloud/initial-state':
+        specifier: ^3.0.0
+        version: 3.0.0
       '@nextcloud/notify_push':
         specifier: ^1.4.0
         version: 1.4.0
@@ -793,36 +796,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
@@ -914,66 +923,79 @@ packages:
     resolution: {integrity: sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.61.1':
     resolution: {integrity: sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.61.1':
     resolution: {integrity: sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.61.1':
     resolution: {integrity: sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.61.1':
     resolution: {integrity: sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.61.1':
     resolution: {integrity: sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.61.1':
     resolution: {integrity: sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.61.1':
     resolution: {integrity: sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.61.1':
     resolution: {integrity: sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.61.1':
     resolution: {integrity: sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.61.1':
     resolution: {integrity: sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.61.1':
     resolution: {integrity: sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.61.1':
     resolution: {integrity: sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.61.1':
     resolution: {integrity: sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==}

--- a/src/App.vue
+++ b/src/App.vue
@@ -16,8 +16,8 @@ import { useRecurringTasks } from './composables/useRecurringTasks'
 import { useTaskEditing } from './composables/useTaskEditing'
 import { useWeekNavigation } from './composables/useWeekNavigation'
 import { useWeekPersistence } from './composables/useWeekPersistence'
-import { ALL_KEYS, DAY_LABELS, WEEKDAY_KEYS, WEEKEND_KEYS } from './types'
-import { getISOWeek, getWeekDates, getWeekMonday } from './utils/dateUtils'
+import { DAY_LABELS, getOrderedKeys } from './types'
+import { getViewDates } from './utils/dateUtils'
 import { emptyWeek, normalizeWeekData } from './utils/weekData'
 
 // --- Shared state ---
@@ -30,10 +30,12 @@ let onWeekLoaded = () => {
 
 // --- Composables ---
 const {
+	viewStart,
 	currentYear,
 	currentWeek,
 	weekDates,
 	weekLabel,
+	bucketKeys,
 	isToday,
 	formatDate,
 	prevWeek,
@@ -42,8 +44,7 @@ const {
 } = useWeekNavigation()
 
 const weekPersistence = useWeekPersistence(
-	currentYear,
-	currentWeek,
+	bucketKeys,
 	weekData,
 	() => onWeekLoaded(),
 )
@@ -52,8 +53,7 @@ const columns = useCustomColumns(recurringTasks)
 const { customColumns, newCustomTasks, addCustomTask, toggleCustomDone, updateColumnTitle } = columns
 
 const recurring = useRecurringTasks(
-	currentYear,
-	currentWeek,
+	weekDates,
 	weekData,
 	recurringTasks,
 	weekPersistence.debouncedSave,
@@ -66,8 +66,20 @@ onWeekLoaded = () => {
 	}
 }
 
-// Stash a task into a future week's server-side data.
-// We do a GET for that week, append the task, then PUT it back.
+// Day key in chronological order, computed so it picks up the user's
+// firstDayOfWeek preference (resolved at boot in main.ts).
+const orderedKeys = computed<DayKey[]>(() => getOrderedKeys())
+// The first five visible days render as standalone columns; the last two are
+// stacked into a single half-width column to give the other days more space.
+// With firstDay=Mon this reproduces the classic five-weekday + Sat/Sun stack
+// layout; for other start days the stacking simply moves to whichever two
+// days fall at the end of the visible window.
+const primaryKeys = computed<DayKey[]>(() => orderedKeys.value.slice(0, 5))
+const stackedKeys = computed<DayKey[]>(() => orderedKeys.value.slice(5, 7))
+
+// Stash a task into a specific (year, week, day) on the server. Used when
+// moving a task to the following week — the target bucket isn't necessarily
+// loaded, so we GET, mutate, PUT.
 async function stashTaskForNextWeek(task: Task, targetDay: DayKey, year: number, week: number) {
 	try {
 		const url = generateUrl('/apps/weekplanner/week/{year}/{week}', {
@@ -79,8 +91,8 @@ async function stashTaskForNextWeek(task: Task, targetDay: DayKey, year: number,
 		data.days[targetDay].push(task)
 		await axios.put(url, data)
 	} catch {
-		// If the fetch fails we fall back to a silent no-op.
-		// The user can navigate to the next week and add the task manually.
+		// If the fetch fails we fall back to a silent no-op. The user can
+		// navigate forwards and add the task manually.
 	}
 }
 
@@ -100,10 +112,9 @@ const {
 	moveEditingTask,
 	moveEditingTaskToNextWeek,
 } = useTaskEditing({
-	currentYear,
-	currentWeek,
+	viewStart,
+	viewDates: weekDates,
 	weekData,
-	weekDates,
 	recurringTasks,
 	customColumns: columns.customColumns,
 	debouncedSave: weekPersistence.debouncedSave,
@@ -118,7 +129,7 @@ const {
 	stashTaskForNextWeek,
 })
 
-const moveDayOptions = computed(() => ALL_KEYS.map((key) => ({
+const moveDayOptions = computed(() => orderedKeys.value.map((key) => ({
 	key,
 	label: DAY_LABELS[key],
 	date: formatDate(key),
@@ -126,17 +137,14 @@ const moveDayOptions = computed(() => ALL_KEYS.map((key) => ({
 })))
 
 const moveNextWeekDayOptions = computed(() => {
-	const monday = getWeekMonday(currentYear.value, currentWeek.value)
-	monday.setDate(monday.getDate() + 7)
-	const nextDates = getWeekDates(getISOWeek(monday).year, getISOWeek(monday).week)
-	return ALL_KEYS.map((key, idx) => {
-		const date = nextDates[idx]
-		return {
-			key,
-			label: DAY_LABELS[key],
-			date: date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
-		}
-	})
+	const nextStart = new Date(viewStart.value)
+	nextStart.setDate(nextStart.getDate() + 7)
+	const nextDates = getViewDates(nextStart)
+	return orderedKeys.value.map((key, idx) => ({
+		key,
+		label: DAY_LABELS[key],
+		date: nextDates[idx].toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
+	}))
 })
 
 const moveColumnOptions = computed(() => customColumns.value.map((c) => ({
@@ -145,14 +153,14 @@ const moveColumnOptions = computed(() => customColumns.value.map((c) => ({
 })))
 
 const polling = usePolling({
-	currentYear,
-	currentWeek,
+	bucketKeys,
 	weekData,
 	editingTask,
 	loadWeek: weekPersistence.loadWeek,
 	loadCustomColumns: columns.loadCustomColumns,
 	materializeRecurringTasks: recurring.materializeRecurringTasks,
 	applyCustomColumnsData: columns.applyCustomColumnsData,
+	applyBucketData: weekPersistence.applyBucketData,
 	isWeekSaveIdle: weekPersistence.isSaveIdle,
 	isWeekLoadIdle: weekPersistence.isLoadIdle,
 	isCustomSaveIdle: columns.isSaveIdle,
@@ -175,11 +183,10 @@ const { onDragChange } = useDragHandler({
 // --- Lifecycle ---
 let mounted = false
 
-watch([currentYear, currentWeek], async () => {
+watch(viewStart, async () => {
 	if (!polling.isUsingNotifyPush()) {
 		polling.stopWeekPoll()
 	}
-	weekPersistence.setKnownUpdatedAt(0)
 	await weekPersistence.loadWeek()
 	if (!polling.isUsingNotifyPush() && mounted) {
 		polling.longPollWeek()
@@ -202,6 +209,12 @@ onUnmounted(() => {
 	weekPersistence.flushSaveTimeout()
 	columns.flushCustomSaveTimeout()
 })
+
+// `currentYear` / `currentWeek` are still destructured for callers (and
+// remain part of the navigation composable's public surface) but are not
+// referenced from this component directly any more.
+void currentYear
+void currentWeek
 </script>
 
 <template>
@@ -227,7 +240,7 @@ onUnmounted(() => {
 
 				<div class="week-grid">
 					<div
-						v-for="day in WEEKDAY_KEYS"
+						v-for="day in primaryKeys"
 						:key="day"
 						class="day-column">
 						<div class="day-header" :class="{ 'is-today': isToday(day) }">
@@ -245,11 +258,11 @@ onUnmounted(() => {
 							@addTask="addTask(day)" />
 					</div>
 
-					<div class="weekend-column">
+					<div class="stacked-column">
 						<div
-							v-for="day in WEEKEND_KEYS"
+							v-for="day in stackedKeys"
 							:key="day"
-							class="weekend-half">
+							class="stacked-half">
 							<div class="day-header day-header-inline" :class="{ 'is-today': isToday(day) }">
 								<span class="day-name">{{ DAY_LABELS[day] }}</span>
 								<span class="day-date">{{ formatDate(day) }}</span>
@@ -351,12 +364,10 @@ onUnmounted(() => {
 	grid-template-columns: repeat(5, 1fr) 0.8fr;
 	gap: 1px;
 	flex: 1 0 auto;
-	/* Pin the weekdays' height so custom-columns can never steal
-	   space from them: as soon as custom grows beyond its minimum,
-	   it pushes the page taller instead of shrinking week-grid.
-	   Reserved (~400px) ≈ NC top bar (~50) + weekplanner padding
-	   (32) + weekplanner-header (~60) + custom-columns minimum
-	   (260). Falls back to 240px on very short viewports. */
+	/* Reserve enough vertical space for the weekday columns regardless of how
+	   tall the custom columns grow. ~400px covers the Nextcloud top bar (~50),
+	   our own padding (32), the planner header (~60), and the custom-columns
+	   minimum (260). */
 	min-height: max(240px, calc(100vh - 400px));
 	background-color: var(--color-border);
 	border: 1px solid var(--color-border);
@@ -370,23 +381,23 @@ onUnmounted(() => {
 	min-height: 0;
 }
 
-.weekend-column {
+.stacked-column {
 	display: flex;
 	flex-direction: column;
 	gap: 1px;
 	background-color: var(--color-border);
 }
 
-.weekend-half {
+.stacked-half {
 	display: flex;
 	flex-direction: column;
 	/* Use auto basis so each half sizes to its content first and only shares
 	   extra space evenly. With `flex: 1` (basis 0) the halves split the parent
-	   50/50 regardless of content, so Saturday's tasks overflow behind Sunday
-	   once they exceed half the row height. The min-height keeps the lighter
-	   half (typically Sunday) at a baseline size when the other half's tasks
-	   push the column taller — without it Sunday would shrink to just the
-	   input field. ~half of the week-grid min-height of 240px. */
+	   50/50 regardless of content, so the first stacked day's tasks would
+	   overflow behind the second once they exceed half the row height. The
+	   min-height keeps the lighter half at a baseline size when the other
+	   half's tasks push the column taller — without it that half would shrink
+	   to just the input field. ~half of the week-grid min-height of 240px. */
 	flex: 1 1 auto;
 	min-height: 120px;
 	background-color: var(--color-main-background);
@@ -399,6 +410,10 @@ onUnmounted(() => {
 	padding: 4px 12px;
 	border-bottom: 1px solid var(--color-border);
 	flex-shrink: 0;
+}
+
+.day-header-inline {
+	flex-direction: row;
 }
 
 .day-header.is-today {
@@ -419,10 +434,6 @@ onUnmounted(() => {
 .day-date {
 	font-size: 11px;
 	color: var(--color-text-maxcontrast);
-}
-
-.day-header-inline {
-	flex-direction: row;
 }
 
 /* Custom columns */
@@ -494,12 +505,12 @@ onUnmounted(() => {
 		border-radius: 8px 8px 0 0;
 	}
 
-	.week-grid .weekend-column {
+	.week-grid .stacked-column {
 		gap: 0;
 	}
 
 	.week-grid .day-column,
-	.week-grid .weekend-half {
+	.week-grid .stacked-half {
 		min-height: 200px;
 	}
 

--- a/src/composables/__tests__/useDragHandler.test.ts
+++ b/src/composables/__tests__/useDragHandler.test.ts
@@ -1,7 +1,8 @@
 import type { RecurringTaskDefinition, Task, WeekData } from '../../types'
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
+import { getViewDates } from '../../utils/dateUtils'
 import { emptyWeek } from '../../utils/weekData'
 import { useCustomColumns } from '../useCustomColumns'
 import { useDragHandler } from '../useDragHandler'
@@ -19,8 +20,7 @@ vi.mock('@nextcloud/router', () => ({
 }))
 
 // Week 12 of 2026: Mon Mar 16 – Sun Mar 22
-const TEST_YEAR = 2026
-const TEST_WEEK = 12
+const VIEW_START = new Date(2026, 2, 16)
 
 function makeTask(title: string): Task {
 	return {
@@ -34,8 +34,8 @@ function makeTask(title: string): Task {
 }
 
 function setup(weekOverride?: WeekData) {
-	const currentYear = ref(TEST_YEAR)
-	const currentWeek = ref(TEST_WEEK)
+	const viewStart = ref(new Date(VIEW_START))
+	const viewDates = computed(() => getViewDates(viewStart.value))
 	const weekData = ref<WeekData>(weekOverride ?? emptyWeek())
 	const recurringTasks = ref<RecurringTaskDefinition[]>([])
 	const debouncedSave = vi.fn()
@@ -45,8 +45,7 @@ function setup(weekOverride?: WeekData) {
 	const debouncedSaveCustomColumnsSpy = vi.spyOn(columns, 'debouncedSaveCustomColumns')
 
 	const { handleDragChange } = useRecurringTasks(
-		currentYear,
-		currentWeek,
+		viewDates,
 		weekData,
 		recurringTasks,
 		debouncedSave,

--- a/src/composables/__tests__/usePolling.test.ts
+++ b/src/composables/__tests__/usePolling.test.ts
@@ -4,7 +4,8 @@ import axios from '@nextcloud/axios'
 import { getCapabilities } from '@nextcloud/capabilities'
 import { listen } from '@nextcloud/notify_push'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
+import { getViewBuckets } from '../../utils/dateUtils'
 import { emptyWeek } from '../../utils/weekData'
 import { usePolling } from '../usePolling'
 
@@ -29,6 +30,8 @@ const mockGetCapabilities = vi.mocked(getCapabilities)
 
 const YEAR = 2026
 const WEEK = 12
+// Monday Mar 16 2026 → ISO week 12, single bucket (firstDay=Mon default).
+const VIEW_START = new Date(2026, 2, 16)
 
 class FakeWebSocketSuccess {
 	onopen: (() => void) | null = null
@@ -61,15 +64,18 @@ function setup(overrides: {
 	const loadWeek = vi.fn().mockResolvedValue(undefined)
 	const loadCustomColumns = vi.fn().mockResolvedValue(undefined)
 
+	const viewStart = ref(new Date(VIEW_START))
+	const bucketKeys = computed(() => getViewBuckets(viewStart.value))
+
 	const polling = usePolling({
-		currentYear: ref(YEAR),
-		currentWeek: ref(WEEK),
+		bucketKeys,
 		weekData: ref(emptyWeek()),
 		editingTask: ref(overrides.editingTask ?? null),
 		loadWeek,
 		loadCustomColumns,
 		materializeRecurringTasks: vi.fn(),
 		applyCustomColumnsData: vi.fn(),
+		applyBucketData: vi.fn(),
 		isWeekSaveIdle: overrides.isWeekSaveIdle ?? (() => true),
 		isWeekLoadIdle: overrides.isWeekLoadIdle ?? (() => true),
 		isCustomSaveIdle: overrides.isCustomSaveIdle ?? (() => true),
@@ -212,16 +218,18 @@ describe('usePolling', () => {
 				},
 			})
 			const materializeRecurringTasks = vi.fn()
+			const viewStart = ref(new Date(VIEW_START))
+			const bucketKeys = computed(() => getViewBuckets(viewStart.value))
 
 			const polling = usePolling({
-				currentYear: ref(YEAR),
-				currentWeek: ref(WEEK),
+				bucketKeys,
 				weekData,
 				editingTask: ref(null),
 				loadWeek: vi.fn(),
 				loadCustomColumns: vi.fn(),
 				materializeRecurringTasks,
 				applyCustomColumnsData: vi.fn(),
+				applyBucketData: vi.fn(),
 				isWeekSaveIdle: () => true,
 				isWeekLoadIdle: () => true,
 				isCustomSaveIdle: () => true,

--- a/src/composables/__tests__/useRecurringTasks.test.ts
+++ b/src/composables/__tests__/useRecurringTasks.test.ts
@@ -1,28 +1,27 @@
 import type { RecurringTaskDefinition, WeekData } from '../../types'
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
+import { getViewDates } from '../../utils/dateUtils'
 import { emptyWeek } from '../../utils/weekData'
 import { useRecurringTasks } from '../useRecurringTasks'
 
 // Week 12 of 2026: Monday Mar 16 - Sunday Mar 22
-const TEST_YEAR = 2026
-const TEST_WEEK = 12
+const VIEW_START = new Date(2026, 2, 16)
 
 function setup(defs: RecurringTaskDefinition[] = [], weekOverride?: WeekData) {
-	const currentYear = ref(TEST_YEAR)
-	const currentWeek = ref(TEST_WEEK)
+	const viewStart = ref(new Date(VIEW_START))
+	const viewDates = computed(() => getViewDates(viewStart.value))
 	const weekData = ref(weekOverride ?? emptyWeek())
 	const recurringTasks = ref(defs)
 	const debouncedSave = vi.fn()
 	const { materializeRecurringTasks } = useRecurringTasks(
-		currentYear,
-		currentWeek,
+		viewDates,
 		weekData,
 		recurringTasks,
 		debouncedSave,
 	)
-	return { currentYear, currentWeek, weekData, recurringTasks, debouncedSave, materializeRecurringTasks }
+	return { viewStart, weekData, recurringTasks, debouncedSave, materializeRecurringTasks }
 }
 
 describe('useRecurringTasks', () => {

--- a/src/composables/__tests__/useTaskEditing.test.ts
+++ b/src/composables/__tests__/useTaskEditing.test.ts
@@ -2,22 +2,21 @@ import type { CustomColumn, RecurringTaskDefinition, Task } from '../../types'
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed, ref } from 'vue'
-import { getWeekDates } from '../../utils/dateUtils'
+import { getViewDates } from '../../utils/dateUtils'
 import { emptyWeek } from '../../utils/weekData'
 import { useTaskEditing } from '../useTaskEditing'
 
-const TEST_YEAR = 2026
-const TEST_WEEK = 12
+// Week 12 of 2026: Monday Mar 16 – Sunday Mar 22.
+const VIEW_START = new Date(2026, 2, 16)
 
 function setup(options: {
 	weekOverride?: ReturnType<typeof emptyWeek>
 	recurringDefs?: RecurringTaskDefinition[]
 	columns?: CustomColumn[]
 } = {}) {
-	const currentYear = ref(TEST_YEAR)
-	const currentWeek = ref(TEST_WEEK)
+	const viewStart = ref(new Date(VIEW_START))
+	const viewDates = computed(() => getViewDates(viewStart.value))
 	const weekData = ref(options.weekOverride ?? emptyWeek())
-	const weekDates = computed(() => getWeekDates(currentYear.value, currentWeek.value))
 	const recurringTasks = ref<RecurringTaskDefinition[]>(options.recurringDefs ?? [])
 	const customColumns = ref<CustomColumn[]>(options.columns ?? [])
 	const debouncedSave = vi.fn()
@@ -32,10 +31,9 @@ function setup(options: {
 	const stashTaskForNextWeek = vi.fn()
 
 	const editing = useTaskEditing({
-		currentYear,
-		currentWeek,
+		viewStart,
+		viewDates,
 		weekData,
-		weekDates,
 		recurringTasks,
 		customColumns,
 		debouncedSave,
@@ -64,6 +62,7 @@ function setup(options: {
 		deleteCustomTask,
 		materializeRecurringTasks,
 		handleDragChange,
+		stashTaskForNextWeek,
 	}
 }
 

--- a/src/composables/__tests__/useWeekPersistence.test.ts
+++ b/src/composables/__tests__/useWeekPersistence.test.ts
@@ -2,7 +2,8 @@ import type { WeekData } from '../../types'
 
 import axios from '@nextcloud/axios'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
+import { getViewBuckets } from '../../utils/dateUtils'
 import { emptyWeek } from '../../utils/weekData'
 import { useWeekPersistence } from '../useWeekPersistence'
 
@@ -18,11 +19,12 @@ const mockGet = vi.mocked(axios.get)
 const mockPut = vi.mocked(axios.put)
 
 function setup(weekOverride?: WeekData) {
-	const currentYear = ref(2026)
-	const currentWeek = ref(12)
+	// Monday Mar 16, 2026 → ISO week 12 of 2026, single bucket (firstDay=Mon).
+	const viewStart = ref(new Date(2026, 2, 16))
+	const bucketKeys = computed(() => getViewBuckets(viewStart.value))
 	const weekData = ref<WeekData>(weekOverride ?? emptyWeek())
 	const onLoaded = vi.fn()
-	const persistence = useWeekPersistence(currentYear, currentWeek, weekData, onLoaded)
+	const persistence = useWeekPersistence(bucketKeys, weekData, onLoaded)
 	return { ...persistence, weekData, onLoaded }
 }
 

--- a/src/composables/usePolling.ts
+++ b/src/composables/usePolling.ts
@@ -1,25 +1,26 @@
-import type { Ref } from 'vue'
+import type { ComputedRef, Ref } from 'vue'
 import type { WeekData } from '../types'
+import type { ViewBucket } from '../utils/dateUtils'
 
 import axios from '@nextcloud/axios'
 import { getCapabilities } from '@nextcloud/capabilities'
 import { generateUrl } from '@nextcloud/router'
-import { normalizeWeekData } from '../utils/weekData'
+import { bucketKey } from '../utils/dateUtils'
 
 interface PollDeps {
-	currentYear: Ref<number>
-	currentWeek: Ref<number>
+	bucketKeys: ComputedRef<ViewBucket[]>
 	weekData: Ref<WeekData>
 	editingTask: Ref<{ day: string, taskId: string } | null>
 	loadWeek: () => Promise<void>
 	loadCustomColumns: () => Promise<void>
 	materializeRecurringTasks: () => void
 	applyCustomColumnsData: (data: unknown) => void
+	applyBucketData: (weekKey: string, data: WeekData) => void
 	isWeekSaveIdle: () => boolean
 	isWeekLoadIdle: () => boolean
 	isCustomSaveIdle: () => boolean
-	getWeekKnownUpdatedAt: () => number
-	setWeekKnownUpdatedAt: (val: number) => void
+	getWeekKnownUpdatedAt: (weekKey: string) => number
+	setWeekKnownUpdatedAt: (weekKey: string, val: number) => void
 	getCustomKnownUpdatedAt: () => number
 	setCustomKnownUpdatedAt: (val: number) => void
 }
@@ -93,7 +94,8 @@ function probeWebSocket(url: string, timeoutMs = WS_PROBE_TIMEOUT_MS): Promise<b
 }
 
 export function usePolling(deps: PollDeps) {
-	let weekPollAbortController: AbortController | null = null
+	// One in-flight long-poll per bucket. Keyed by `${year}-${week}`.
+	const weekPollAbortControllers = new Map<string, AbortController>()
 	let shouldPollWeek = false
 	let customPollAbortController: AbortController | null = null
 	let shouldPollCustom = false
@@ -103,29 +105,37 @@ export function usePolling(deps: PollDeps) {
 
 	function stopWeekPoll() {
 		shouldPollWeek = false
-		weekPollAbortController?.abort()
-		weekPollAbortController = null
+		for (const c of weekPollAbortControllers.values()) {
+			c.abort()
+		}
+		weekPollAbortControllers.clear()
 	}
 
-	async function longPollWeek() {
+	async function pollBucket(year: number, week: number) {
+		const key = bucketKey(year, week)
 		if (!shouldPollWeek) {
 			return
 		}
+		// If the visible window no longer includes this bucket, stop polling it.
+		if (!deps.bucketKeys.value.some((b) => b.weekKey === key)) {
+			weekPollAbortControllers.delete(key)
+			return
+		}
 		const controller = new AbortController()
-		weekPollAbortController = controller
+		weekPollAbortControllers.set(key, controller)
 		try {
 			const url = generateUrl('/apps/weekplanner/week/{year}/{week}/poll', {
-				year: String(deps.currentYear.value),
-				week: String(deps.currentWeek.value),
+				year: String(year),
+				week: String(week),
 			})
 			const response = await axios.get<{ changed: boolean, updatedAt: number, data?: unknown }>(
-				`${url}?since=${deps.getWeekKnownUpdatedAt()}`,
+				`${url}?since=${deps.getWeekKnownUpdatedAt(key)}`,
 				{ signal: controller.signal, timeout: 35_000 },
 			)
 			if (response.data.changed && response.data.data !== undefined && response.data.data !== null) {
 				if (deps.isWeekSaveIdle() && !deps.editingTask.value) {
-					deps.setWeekKnownUpdatedAt(response.data.updatedAt)
-					deps.weekData.value = normalizeWeekData(response.data.data)
+					deps.setWeekKnownUpdatedAt(key, response.data.updatedAt)
+					deps.applyBucketData(key, response.data.data as WeekData)
 					deps.materializeRecurringTasks()
 				}
 			}
@@ -135,7 +145,19 @@ export function usePolling(deps: PollDeps) {
 			}
 			await new Promise((resolve) => setTimeout(resolve, 5_000))
 		}
-		longPollWeek()
+		pollBucket(year, week)
+	}
+
+	function longPollWeek() {
+		if (!shouldPollWeek) {
+			return
+		}
+		// Spin up one long-poll loop per bucket in the current visible window.
+		for (const bucket of deps.bucketKeys.value) {
+			if (!weekPollAbortControllers.has(bucket.weekKey)) {
+				pollBucket(bucket.year, bucket.week)
+			}
+		}
 	}
 
 	// --- Custom columns polling ---
@@ -210,7 +232,8 @@ export function usePolling(deps: PollDeps) {
 				if (!body) {
 					return
 				}
-				if (Number(body.year) === deps.currentYear.value && Number(body.week) === deps.currentWeek.value) {
+				const key = bucketKey(Number(body.year), Number(body.week))
+				if (deps.bucketKeys.value.some((b) => b.weekKey === key)) {
 					if (deps.isWeekSaveIdle() && deps.isWeekLoadIdle() && !deps.editingTask.value) {
 						deps.loadWeek()
 					}

--- a/src/composables/useRecurringTasks.ts
+++ b/src/composables/useRecurringTasks.ts
@@ -1,26 +1,27 @@
-import type { Ref } from 'vue'
-import type { CustomColumn, RecurringTaskDefinition, WeekData } from '../types'
+import type { ComputedRef, Ref } from 'vue'
+import type { CustomColumn, DayKey, RecurringTaskDefinition, WeekData } from '../types'
 
-import { ALL_KEYS } from '../types'
-import { getWeekDates, toDateStr } from '../utils/dateUtils'
+import { dayOfWeekMonFirst, getDayKeyOfDate, toDateStr } from '../utils/dateUtils'
 import { randomId } from '../utils/randomId'
 
 export function useRecurringTasks(
-	currentYear: Ref<number>,
-	currentWeek: Ref<number>,
+	viewDates: ComputedRef<Date[]>,
 	weekData: Ref<WeekData>,
 	recurringTasks: Ref<RecurringTaskDefinition[]>,
 	debouncedSave: () => void,
 	customColumns?: Ref<CustomColumn[]>,
 ) {
 	function materializeRecurringTasks() {
-		const dates = getWeekDates(currentYear.value, currentWeek.value)
+		const dates = viewDates.value
 		let changed = false
 
-		// Clean up stale recurring instances (definition ended, deleted, or no longer matching pattern)
-		for (let i = 0; i < ALL_KEYS.length; i++) {
-			const day = ALL_KEYS[i]
-			const dateStr = toDateStr(dates[i])
+		// Clean up stale recurring instances (definition ended, deleted, or no
+		// longer matching pattern). We iterate the visible window by date and
+		// look up each date's storage slot via its day-of-week key.
+		for (const date of dates) {
+			const day: DayKey = getDayKeyOfDate(date)
+			const dateStr = toDateStr(date)
+			const canonicalDow = dayOfWeekMonFirst(date)
 			const before = weekData.value.days[day].length
 			weekData.value.days[day] = weekData.value.days[day].filter((t) => {
 				if (!t.recurringSourceId) {
@@ -37,10 +38,10 @@ export function useRecurringTasks(
 				const wasMovedHere = t.recurringOriginalDate && t.recurringOriginalDate !== dateStr
 				// Remove instances that no longer match the current recurrence pattern
 				// (e.g. after changing from weekly to monthly) — but not moved instances
-				if (!wasMovedHere && def.recurrence === 'weekly' && i !== def.dayOfWeek) {
+				if (!wasMovedHere && def.recurrence === 'weekly' && canonicalDow !== def.dayOfWeek) {
 					return false
 				}
-				if (!wasMovedHere && def.recurrence === 'monthly' && dates[i].getDate() !== def.dayOfMonth) {
+				if (!wasMovedHere && def.recurrence === 'monthly' && date.getDate() !== def.dayOfMonth) {
 					return false
 				}
 				if (!wasMovedHere && def.exceptionDates?.includes(dateStr)) {
@@ -54,10 +55,10 @@ export function useRecurringTasks(
 		}
 
 		// Materialize new instances
-		for (let i = 0; i < ALL_KEYS.length; i++) {
-			const day = ALL_KEYS[i]
-			const date = dates[i]
+		for (const date of dates) {
+			const day: DayKey = getDayKeyOfDate(date)
 			const dateStr = toDateStr(date)
+			const canonicalDow = dayOfWeekMonFirst(date)
 			for (const def of recurringTasks.value) {
 				if (dateStr < def.startDate) {
 					continue
@@ -69,7 +70,7 @@ export function useRecurringTasks(
 				if (def.recurrence === 'daily') {
 					matches = true
 				} else if (def.recurrence === 'weekly') {
-					matches = i === def.dayOfWeek
+					matches = canonicalDow === def.dayOfWeek
 				} else if (def.recurrence === 'monthly') {
 					matches = date.getDate() === def.dayOfMonth
 				}
@@ -101,7 +102,7 @@ export function useRecurringTasks(
 	}
 
 	function handleDragChange(): boolean {
-		const dates = getWeekDates(currentYear.value, currentWeek.value)
+		const dates = viewDates.value
 		let definitionsChanged = false
 
 		// Check custom columns: recurring tasks moved here need an exception on their original date
@@ -116,15 +117,16 @@ export function useRecurringTasks(
 						continue
 					}
 					if (!task.recurringOriginalDate) {
-						for (let i = 0; i < ALL_KEYS.length; i++) {
-							const ds = toDateStr(dates[i])
+						for (const date of dates) {
+							const ds = toDateStr(date)
+							const canonicalDow = dayOfWeekMonFirst(date)
 							let matches = false
 							if (def.recurrence === 'daily') {
 								matches = true
 							} else if (def.recurrence === 'weekly') {
-								matches = i === def.dayOfWeek
+								matches = canonicalDow === def.dayOfWeek
 							} else if (def.recurrence === 'monthly') {
-								matches = dates[i].getDate() === def.dayOfMonth
+								matches = date.getDate() === def.dayOfMonth
 							}
 							if (matches && ds >= def.startDate && (!def.endDate || ds <= def.endDate)) {
 								task.recurringOriginalDate = ds
@@ -141,9 +143,9 @@ export function useRecurringTasks(
 		}
 
 		// Check day slots: recurring tasks moved to a different day need an exception on original date
-		for (let i = 0; i < ALL_KEYS.length; i++) {
-			const day = ALL_KEYS[i]
-			const dateStr = toDateStr(dates[i])
+		for (const date of dates) {
+			const day: DayKey = getDayKeyOfDate(date)
+			const dateStr = toDateStr(date)
 			for (const task of weekData.value.days[day]) {
 				if (!task.recurringSourceId) {
 					continue

--- a/src/composables/useTaskEditing.ts
+++ b/src/composables/useTaskEditing.ts
@@ -3,14 +3,19 @@ import type { CustomColumn, DayKey, Recurrence, RecurringDeleteMode, RecurringTa
 
 import { computed, nextTick, ref } from 'vue'
 import { ALL_KEYS } from '../types'
-import { getISOWeek, getWeekDates, getWeekMonday, toDateStr } from '../utils/dateUtils'
+import {
+	dayOfWeekMonFirst,
+	getDayKeyOfDate,
+	getISOWeek,
+	getViewDates,
+	toDateStr,
+} from '../utils/dateUtils'
 import { randomId } from '../utils/randomId'
 
 export interface TaskEditingDeps {
-	currentYear: Ref<number>
-	currentWeek: Ref<number>
+	viewStart: Ref<Date>
+	viewDates: ComputedRef<Date[]>
 	weekData: Ref<WeekData>
-	weekDates: ComputedRef<Date[]>
 	recurringTasks: Ref<RecurringTaskDefinition[]>
 	customColumns: Ref<CustomColumn[]>
 	debouncedSave: () => void
@@ -27,10 +32,9 @@ export interface TaskEditingDeps {
 
 export function useTaskEditing(deps: TaskEditingDeps) {
 	const {
-		currentYear,
-		currentWeek,
+		viewStart,
+		viewDates,
 		weekData,
-		weekDates,
 		recurringTasks,
 		customColumns,
 		debouncedSave,
@@ -75,10 +79,19 @@ export function useTaskEditing(deps: TaskEditingDeps) {
 		})
 	}
 
+	/**
+	 * Find the visible-week Date whose day-of-week matches `day`.
+	 *
+	 * @param day
+	 * @param dates
+	 */
+	function dateForDay(day: DayKey, dates: Date[] = viewDates.value): Date | undefined {
+		return dates.find((d) => getDayKeyOfDate(d) === day)
+	}
+
 	function getTaskDate(day: DayKey): string {
-		const idx = ALL_KEYS.indexOf(day)
-		const dates = getWeekDates(currentYear.value, currentWeek.value)
-		return toDateStr(dates[idx])
+		const date = dateForDay(day)
+		return date ? toDateStr(date) : ''
 	}
 
 	function handleRecurrenceChange(task: Task, day: DayKey) {
@@ -88,8 +101,11 @@ export function useTaskEditing(deps: TaskEditingDeps) {
 		if (newRecurrence && !oldSourceId) {
 			// Setting recurrence for the first time: create a definition
 			const defId = randomId()
-			const dateStr = getTaskDate(day)
-			const date = weekDates.value[ALL_KEYS.indexOf(day)]
+			const date = dateForDay(day)
+			if (!date) {
+				return
+			}
+			const dateStr = toDateStr(date)
 			recurringTasks.value.push({
 				id: defId,
 				title: editTitle.value.trim() || task.title,
@@ -97,7 +113,7 @@ export function useTaskEditing(deps: TaskEditingDeps) {
 				recurrence: newRecurrence as 'daily' | 'weekly' | 'monthly',
 				startDate: dateStr,
 				endDate: '',
-				dayOfWeek: ALL_KEYS.indexOf(day),
+				dayOfWeek: dayOfWeekMonFirst(date),
 				dayOfMonth: date.getDate(),
 				exceptionDates: [],
 			})
@@ -125,12 +141,12 @@ export function useTaskEditing(deps: TaskEditingDeps) {
 				def.endDate = dateStr
 			}
 			task.recurrence = ''
-			// Remove instances from days after endDate in this week
-			const dates = getWeekDates(currentYear.value, currentWeek.value)
-			for (let i = 0; i < ALL_KEYS.length; i++) {
-				const dStr = toDateStr(dates[i])
+			// Remove future-of-this-day instances within the visible window.
+			for (const date of viewDates.value) {
+				const dStr = toDateStr(date)
 				if (dStr > dateStr) {
-					weekData.value.days[ALL_KEYS[i]] = weekData.value.days[ALL_KEYS[i]].filter((t) => t.recurringSourceId !== oldSourceId)
+					const key = getDayKeyOfDate(date)
+					weekData.value.days[key] = weekData.value.days[key].filter((t) => t.recurringSourceId !== oldSourceId)
 				}
 			}
 			debouncedSaveCustomColumns()
@@ -213,11 +229,11 @@ export function useTaskEditing(deps: TaskEditingDeps) {
 						prev.setDate(prev.getDate() - 1)
 						def.endDate = toDateStr(prev)
 					}
-					const dates = getWeekDates(currentYear.value, currentWeek.value)
-					for (let i = 0; i < ALL_KEYS.length; i++) {
-						const dStr = toDateStr(dates[i])
+					for (const date of viewDates.value) {
+						const dStr = toDateStr(date)
 						if (dStr >= dateStr) {
-							weekData.value.days[ALL_KEYS[i]] = weekData.value.days[ALL_KEYS[i]].filter((t) => t.recurringSourceId !== sourceId)
+							const key = getDayKeyOfDate(date)
+							weekData.value.days[key] = weekData.value.days[key].filter((t) => t.recurringSourceId !== sourceId)
 						}
 					}
 					flushSaveTimeout()
@@ -316,12 +332,11 @@ export function useTaskEditing(deps: TaskEditingDeps) {
 
 		if (isRecurringDayToDay) {
 			const def = recurringTasks.value.find((d) => d.id === task!.recurringSourceId)
-			if (def) {
-				const targetIdx = ALL_KEYS.indexOf(target as DayKey)
-				const targetDateStr = toDateStr(weekDates.value[targetIdx])
-				const targetDate = weekDates.value[targetIdx]
+			const targetDate = dateForDay(target as DayKey)
+			if (def && targetDate) {
+				const targetDateStr = toDateStr(targetDate)
 				def.startDate = targetDateStr
-				def.dayOfWeek = targetIdx
+				def.dayOfWeek = dayOfWeekMonFirst(targetDate)
 				def.dayOfMonth = targetDate.getDate()
 				def.exceptionDates = def.exceptionDates.filter((d) => d >= targetDateStr)
 				task.recurringOriginalDate = targetDateStr
@@ -366,20 +381,11 @@ export function useTaskEditing(deps: TaskEditingDeps) {
 		return !!task?.recurringSourceId
 	})
 
-	// Move the currently edited task to a given day in the following week.
-	// The task is removed from the current day/column, then injected into the
-	// next week's week-data via a temporary year+week offset.  Because
-	// weekData only holds the currently-visible week, we delegate persistence
-	// to saveWeekNow/loadWeek-cycle: we save the current week first (task
-	// removed), then navigate the caller to the next week so the normal
-	// loadWeek picks up a fresh slice — except we can't navigate from here.
-	// Instead we adopt the simpler and equally correct approach: stash the
-	// task in localStorage under the target week key so it will be merged in
-	// on the next load.  For non-recurring tasks this is the cleanest option
-	// with zero coupling to the navigation layer.
-	//
-	// Implementation: we emit the task + target info upward via a callback
-	// injected through deps so App.vue stays in control of cross-week storage.
+	// Move the currently edited task to a day in the following visible week.
+	// "Next week" here is the view shifted +7 days, regardless of how the
+	// user's firstDayOfWeek aligns with ISO weeks. We resolve the target date
+	// inside that shifted window, derive its ISO-week storage bucket, and hand
+	// off to the cross-week stasher.
 	function moveEditingTaskToNextWeek(targetDay: DayKey) {
 		if (!editingTask.value) {
 			return
@@ -412,13 +418,19 @@ export function useTaskEditing(deps: TaskEditingDeps) {
 		flushSaveTimeout()
 		saveWeekNow()
 
-		// Compute target week (current week + 7 days from Monday)
-		const monday = getWeekMonday(currentYear.value, currentWeek.value)
-		monday.setDate(monday.getDate() + 7)
-		const { year: nextYear, week: nextWeek } = getISOWeek(monday)
+		// Resolve target date in the next visible week's chronological dates
+		// and find which ISO-week bucket it belongs to.
+		const nextViewStart = new Date(viewStart.value)
+		nextViewStart.setDate(nextViewStart.getDate() + 7)
+		const nextDates = getViewDates(nextViewStart)
+		const targetDate = dateForDay(targetDay, nextDates)
+		if (!targetDate) {
+			editingTask.value = null
+			return
+		}
+		const { year, week } = getISOWeek(targetDate)
 
-		// Delegate cross-week stashing to the injected callback
-		deps.stashTaskForNextWeek(task, targetDay, nextYear, nextWeek)
+		deps.stashTaskForNextWeek(task, targetDay, year, week)
 
 		editingTask.value = null
 	}

--- a/src/composables/useWeekNavigation.ts
+++ b/src/composables/useWeekNavigation.ts
@@ -1,30 +1,54 @@
 import type { DayKey } from '../types'
 
 import { computed, ref } from 'vue'
-import { ALL_KEYS } from '../types'
-import { getISOWeek, getWeekDates, getWeekMonday } from '../utils/dateUtils'
+import { getFirstDayOfWeek, getOrderedKeys } from '../types'
+import { getISOWeek, getViewBuckets, getViewDates, getViewStart } from '../utils/dateUtils'
 
 export function useWeekNavigation() {
-	const { year: _initYear, week: _initWeek } = getISOWeek(new Date())
-	const currentYear = ref(_initYear)
-	const currentWeek = ref(_initWeek)
+	// Source of truth for the visible window: the first day shown, at local midnight.
+	const viewStart = ref<Date>(getViewStart(new Date(), getFirstDayOfWeek()))
 
-	const weekDates = computed(() => getWeekDates(currentYear.value, currentWeek.value))
+	const weekDates = computed(() => getViewDates(viewStart.value))
+
+	// Buckets the visible window draws from. 1 when firstDay = Monday (window
+	// aligns with ISO week), 2 otherwise.
+	const bucketKeys = computed(() => getViewBuckets(viewStart.value))
+
+	// Best-effort single ISO-week label for the visible window. We pick the ISO
+	// week of the date closest to mid-window (day 3) so a Sunday-start view of
+	// e.g. Sun Jun 21 – Sat Jun 27 still labels as the Mon-anchored ISO week
+	// rather than the trailing one.
+	const labelISOWeek = computed(() => getISOWeek(weekDates.value[3]))
+
+	// Kept for backward compatibility with code/tests that destructure these.
+	// They reflect the labelISOWeek; mutating them (as legacy tests do) snaps
+	// the view to that ISO week's first-day-aligned window.
+	const currentYear = computed({
+		get: () => labelISOWeek.value.year,
+		set: (year: number) => {
+			snapToISOWeek(year, labelISOWeek.value.week)
+		},
+	})
+	const currentWeek = computed({
+		get: () => labelISOWeek.value.week,
+		set: (week: number) => {
+			snapToISOWeek(labelISOWeek.value.year, week)
+		},
+	})
 
 	const weekLabel = computed(() => {
 		const dates = weekDates.value
 		if (dates.length === 0) {
 			return ''
 		}
-		const mon = dates[0]
-		const sun = dates[6]
+		const start = dates[0]
+		const end = dates[6]
 		const fmt = (d: Date) => d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
-		const yearStr = sun.getFullYear()
-		return `Week ${currentWeek.value} \u00B7 ${fmt(mon)} \u2013 ${fmt(sun)}, ${yearStr}`
+		return `Week ${labelISOWeek.value.week} \u00B7 ${fmt(start)} \u2013 ${fmt(end)}, ${end.getFullYear()}`
 	})
 
 	function dayIndex(day: DayKey): number {
-		return ALL_KEYS.indexOf(day)
+		return getOrderedKeys().indexOf(day)
 	}
 
 	function isToday(day: DayKey): boolean {
@@ -48,33 +72,41 @@ export function useWeekNavigation() {
 		return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
 	}
 
+	function shiftDays(days: number) {
+		const next = new Date(viewStart.value)
+		next.setDate(next.getDate() + days)
+		viewStart.value = next
+	}
+
 	function prevWeek() {
-		const monday = getWeekMonday(currentYear.value, currentWeek.value)
-		monday.setDate(monday.getDate() - 7)
-		const { year, week } = getISOWeek(monday)
-		currentYear.value = year
-		currentWeek.value = week
+		shiftDays(-7)
 	}
 
 	function nextWeek() {
-		const monday = getWeekMonday(currentYear.value, currentWeek.value)
-		monday.setDate(monday.getDate() + 7)
-		const { year, week } = getISOWeek(monday)
-		currentYear.value = year
-		currentWeek.value = week
+		shiftDays(7)
 	}
 
 	function goToday() {
-		const { year, week } = getISOWeek(new Date())
-		currentYear.value = year
-		currentWeek.value = week
+		viewStart.value = getViewStart(new Date(), getFirstDayOfWeek())
+	}
+
+	function snapToISOWeek(year: number, week: number) {
+		// Anchor to the Monday of the requested ISO week, then back up to the
+		// preferred first day. Keeps user-visible navigation by ISO week-number
+		// consistent regardless of firstDayOfWeek.
+		const monday = new Date(year, 0, 4)
+		const dow = monday.getDay() || 7
+		monday.setDate(monday.getDate() - dow + 1 + (week - 1) * 7)
+		viewStart.value = getViewStart(monday, getFirstDayOfWeek())
 	}
 
 	return {
+		viewStart,
 		currentYear,
 		currentWeek,
 		weekDates,
 		weekLabel,
+		bucketKeys,
 		dayIndex,
 		isToday,
 		formatDate,

--- a/src/composables/useWeekPersistence.ts
+++ b/src/composables/useWeekPersistence.ts
@@ -1,37 +1,64 @@
-import type { Ref } from 'vue'
+import type { ComputedRef, Ref } from 'vue'
 import type { WeekData } from '../types'
+import type { ViewBucket } from '../utils/dateUtils'
 
 import axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
 import { createDebouncedSave } from '../utils/debounce'
-import { normalizeWeekData } from '../utils/weekData'
+import { emptyWeek, normalizeWeekData } from '../utils/weekData'
 
 export function useWeekPersistence(
-	currentYear: Ref<number>,
-	currentWeek: Ref<number>,
+	bucketKeys: ComputedRef<ViewBucket[]>,
 	weekData: Ref<WeekData>,
 	onLoaded: () => void,
 ) {
+	// Raw per-ISO-week data, keyed by `${year}-${week}`. We retain the full Mon-Sun
+	// shape (not just the visible slice) so that when we save we can preserve the
+	// day keys that aren't visible in the current view — without this, a save
+	// triggered by editing one day in bucket A would wipe the other days in
+	// bucket A that the user can't see.
+	const bucketCache = new Map<string, WeekData>()
+	const knownUpdatedAt = new Map<string, number>()
+
 	let isLoading = false
-	let knownWeekUpdatedAt = 0
 	let loadAbortController: AbortController | null = null
 	let setSaveInProgress: (val: boolean) => void = () => {
 		/* assigned after save is created */
 	}
 
+	function urlFor(year: number, week: number): string {
+		return generateUrl('/apps/weekplanner/week/{year}/{week}', {
+			year: String(year),
+			week: String(week),
+		})
+	}
+
+	function buildPayload(bucket: ViewBucket): WeekData {
+		const cached = bucketCache.get(bucket.weekKey) ?? emptyWeek()
+		const merged: WeekData = { days: { ...cached.days } }
+		// Overwrite in-view day keys with the current merged-view values. Days
+		// outside the visible window stay as their cached values.
+		for (const dayKey of bucket.dayKeys) {
+			merged.days[dayKey] = weekData.value.days[dayKey]
+		}
+		return merged
+	}
+
 	async function saveWeekNow() {
 		setSaveInProgress(true)
 		try {
-			const url = generateUrl('/apps/weekplanner/week/{year}/{week}', {
-				year: String(currentYear.value),
-				week: String(currentWeek.value),
-			})
-			const response = await axios.put(url, weekData.value)
-			if (typeof response.data?.updatedAt === 'number') {
-				knownWeekUpdatedAt = response.data.updatedAt
-			}
-		} catch {
-			// Save failed silently
+			await Promise.all(bucketKeys.value.map(async (bucket) => {
+				const payload = buildPayload(bucket)
+				try {
+					const response = await axios.put(urlFor(bucket.year, bucket.week), payload)
+					bucketCache.set(bucket.weekKey, payload)
+					if (typeof response.data?.updatedAt === 'number') {
+						knownUpdatedAt.set(bucket.weekKey, response.data.updatedAt)
+					}
+				} catch {
+					// Save failed for this bucket; leave its cache untouched.
+				}
+			}))
 		} finally {
 			setSaveInProgress(false)
 		}
@@ -40,37 +67,90 @@ export function useWeekPersistence(
 	const save = createDebouncedSave(saveWeekNow)
 	setSaveInProgress = save.setInProgress
 
+	function assembleWeekData() {
+		const next = emptyWeek()
+		for (const bucket of bucketKeys.value) {
+			const cached = bucketCache.get(bucket.weekKey)
+			if (!cached) {
+				continue
+			}
+			for (const dayKey of bucket.dayKeys) {
+				next.days[dayKey] = cached.days[dayKey]
+			}
+		}
+		weekData.value = next
+	}
+
 	async function loadWeek() {
 		loadAbortController?.abort()
 		const controller = new AbortController()
 		loadAbortController = controller
 		isLoading = true
 		try {
-			const url = generateUrl('/apps/weekplanner/week/{year}/{week}', {
-				year: String(currentYear.value),
-				week: String(currentWeek.value),
-			})
-			const response = await axios.get(url, { signal: controller.signal })
+			const buckets = bucketKeys.value
+			const responses = await Promise.all(buckets.map((bucket) => axios
+				.get(urlFor(bucket.year, bucket.week), { signal: controller.signal })
+				.then((response) => ({ bucket, response }))
+				.catch(() => null)))
 			if (controller.signal.aborted) {
 				return
 			}
-			if (!save.isIdle()) {
-				return
+
+			// Apply only when a save isn't pending (it would overwrite the
+			// user's unsaved local edits) and at least one fetch succeeded.
+			// If every fetch failed we still call onLoaded below so dependent
+			// initial setup runs, but we leave the existing in-memory weekData
+			// alone — likely a transient network blip.
+			const anySucceeded = responses.some((r) => r !== null)
+			if (save.isIdle() && anySucceeded) {
+				// Reset cache to only the buckets currently in view so navigating
+				// elsewhere doesn't leak stale data into a later save merge.
+				const visibleKeys = new Set(buckets.map((b) => b.weekKey))
+				for (const key of [...bucketCache.keys()]) {
+					if (!visibleKeys.has(key)) {
+						bucketCache.delete(key)
+						knownUpdatedAt.delete(key)
+					}
+				}
+
+				for (const entry of responses) {
+					if (!entry) {
+						continue
+					}
+					const { bucket, response } = entry
+					bucketCache.set(bucket.weekKey, normalizeWeekData(response.data))
+					if (typeof response.data?.updatedAt === 'number') {
+						knownUpdatedAt.set(bucket.weekKey, response.data.updatedAt)
+					}
+				}
+				assembleWeekData()
 			}
-			weekData.value = normalizeWeekData(response.data)
-			if (typeof response.data?.updatedAt === 'number') {
-				knownWeekUpdatedAt = response.data.updatedAt
-			}
-		} catch {
-			if (controller.signal.aborted) {
-				return
-			}
+			onLoaded()
 		} finally {
 			if (!controller.signal.aborted) {
 				isLoading = false
 			}
 		}
-		onLoaded()
+	}
+
+	function getKnownUpdatedAt(weekKey: string): number {
+		return knownUpdatedAt.get(weekKey) ?? 0
+	}
+
+	function setKnownUpdatedAt(weekKey: string, val: number) {
+		knownUpdatedAt.set(weekKey, val)
+	}
+
+	/**
+	 * Replace an entire bucket's cached data with `data` and re-assemble the
+	 * merged view. Used by polling / notify_push to apply external updates.
+	 *
+	 * @param weekKey
+	 * @param data
+	 */
+	function applyBucketData(weekKey: string, data: WeekData) {
+		bucketCache.set(weekKey, normalizeWeekData(data))
+		assembleWeekData()
 	}
 
 	return {
@@ -78,10 +158,9 @@ export function useWeekPersistence(
 		saveWeekNow,
 		debouncedSave: save.trigger,
 		flushSaveTimeout: save.flush,
-		getKnownUpdatedAt: () => knownWeekUpdatedAt,
-		setKnownUpdatedAt: (val: number) => {
-			knownWeekUpdatedAt = val
-		},
+		getKnownUpdatedAt,
+		setKnownUpdatedAt,
+		applyBucketData,
 		isSaveIdle: save.isIdle,
 		isLoadIdle: () => !isLoading,
 	}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,16 @@
+import { loadState } from '@nextcloud/initial-state'
 import { createApp } from 'vue'
 import App from './App.vue'
+import { setFirstDayOfWeek } from './types'
+
+// Pull the user's preferred first day of week before the root component mounts
+// so reactive computeds inside App.vue see the correct value on first render.
+try {
+	const firstDay = loadState<number>('weekplanner', 'firstDayOfWeek', 1)
+	setFirstDayOfWeek(Number(firstDay))
+} catch {
+	// Backend not exposing initial state (e.g. legacy install) — default to Monday.
+}
 
 const app = createApp(App)
 app.mount('#weekplanner')

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,7 @@ export interface RecurringTaskDefinition {
 	recurrence: 'daily' | 'weekly' | 'monthly'
 	startDate: string
 	endDate: string
+	/** 0=Monday..6=Sunday — canonical day of week, independent of the user's firstDayOfWeek display preference. */
 	dayOfWeek: number
 	dayOfMonth: number
 	exceptionDates: string[]
@@ -48,8 +49,10 @@ export interface CustomColumn {
 	tasks: Task[]
 }
 
-export const WEEKDAY_KEYS: DayKey[] = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday']
-export const WEEKEND_KEYS: DayKey[] = ['saturday', 'sunday']
+// Canonical Monday-first key list. Used for iteration where order is irrelevant
+// (e.g. clearing all days, normalising backend payloads).
+export const ALL_KEYS: DayKey[] = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday']
+
 export const DAY_LABELS: Record<DayKey, string> = {
 	monday: 'Monday',
 	tuesday: 'Tuesday',
@@ -59,4 +62,36 @@ export const DAY_LABELS: Record<DayKey, string> = {
 	saturday: 'Saturday',
 	sunday: 'Sunday',
 }
-export const ALL_KEYS: DayKey[] = [...WEEKDAY_KEYS, ...WEEKEND_KEYS]
+
+// User's preferred first day of week as 0=Sunday..6=Saturday (Nextcloud convention).
+// Mutable module singleton: set once from initial state at app boot, read by
+// composables thereafter. A reload picks up changes — there is no reactivity
+// because Personal info preference changes already require a page reload.
+let firstDayOfWeekValue = 1
+
+export function setFirstDayOfWeek(value: number): void {
+	const normalized = ((value % 7) + 7) % 7
+	firstDayOfWeekValue = normalized
+}
+
+export function getFirstDayOfWeek(): number {
+	return firstDayOfWeekValue
+}
+
+// JS getDay() convention (0=Sun..6=Sat) → canonical DayKey (Mon-Sun list index).
+const KEY_FOR_JS_DAY: DayKey[] = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday']
+
+/**
+ * Day keys in the user's preferred display order, starting at firstDayOfWeek.
+ * For firstDay=1 (Mon, default): ['monday'..'sunday']. For firstDay=0 (Sun):
+ * ['sunday', 'monday'..'saturday']. Used for rendering and for paired iteration
+ * with the visible week's chronological dates.
+ */
+export function getOrderedKeys(): DayKey[] {
+	const start = firstDayOfWeekValue
+	const result: DayKey[] = []
+	for (let i = 0; i < 7; i++) {
+		result.push(KEY_FOR_JS_DAY[(start + i) % 7])
+	}
+	return result
+}

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -1,3 +1,19 @@
+import type { DayKey } from '../types'
+
+// Canonical day-of-week order, Monday=0..Sunday=6. This matches ISO 8601 and is
+// the storage convention for both backend buckets (day keys) and recurring
+// definitions' `dayOfWeek` field — independent of the user's preferred
+// firstDayOfWeek display order.
+const DAY_KEYS_MON_FIRST: DayKey[] = [
+	'monday',
+	'tuesday',
+	'wednesday',
+	'thursday',
+	'friday',
+	'saturday',
+	'sunday',
+]
+
 export function getISOWeek(date: Date): { year: number, week: number } {
 	const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()))
 	d.setUTCDate(d.getUTCDate() + 4 - (d.getUTCDay() || 7))
@@ -29,4 +45,96 @@ export function getWeekDates(year: number, week: number): Date[] {
 
 export function toDateStr(d: Date): string {
 	return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+/**
+ * 0=Monday..6=Sunday — canonical storage index for day-of-week, decoupled from
+ * the user's firstDayOfWeek display order. Used by recurring task definitions.
+ *
+ * @param date
+ */
+export function dayOfWeekMonFirst(date: Date): number {
+	// JS getDay() returns 0=Sunday..6=Saturday.
+	const js = date.getDay()
+	return (js + 6) % 7
+}
+
+/**
+ * DayKey corresponding to the actual day of week of the given date. Used to
+ * locate a date's task list inside an ISO-week-keyed bucket.
+ *
+ * @param date
+ */
+export function getDayKeyOfDate(date: Date): DayKey {
+	return DAY_KEYS_MON_FIRST[dayOfWeekMonFirst(date)]
+}
+
+/**
+ * Latest occurrence of `firstDay` (0=Sun..6=Sat in JS convention, matching
+ * Nextcloud's stored preference) on or before `date`, at local midnight.
+ *
+ * @param date
+ * @param firstDay
+ */
+export function getViewStart(date: Date, firstDay: number): Date {
+	const normalized = ((firstDay % 7) + 7) % 7
+	const result = new Date(date.getFullYear(), date.getMonth(), date.getDate())
+	const diff = (result.getDay() - normalized + 7) % 7
+	result.setDate(result.getDate() - diff)
+	return result
+}
+
+/**
+ * 7 consecutive dates starting at `viewStart`.
+ *
+ * @param viewStart
+ */
+export function getViewDates(viewStart: Date): Date[] {
+	const dates: Date[] = []
+	for (let i = 0; i < 7; i++) {
+		const d = new Date(viewStart)
+		d.setDate(viewStart.getDate() + i)
+		dates.push(d)
+	}
+	return dates
+}
+
+export interface ViewBucket {
+	year: number
+	week: number
+	weekKey: string
+	/** Day keys from this bucket that appear in the visible view, in chronological order. */
+	dayKeys: DayKey[]
+	/** Chronological dates matching `dayKeys` 1:1. */
+	dates: Date[]
+}
+
+/**
+ * Group the 7 visible dates by ISO week. Returns 1 or 2 buckets in
+ * chronological order — 1 when the view aligns with an ISO week (firstDay
+ * = Monday), 2 otherwise.
+ *
+ * @param viewStart
+ */
+export function getViewBuckets(viewStart: Date): ViewBucket[] {
+	const dates = getViewDates(viewStart)
+	const buckets = new Map<string, ViewBucket>()
+	const order: string[] = []
+	for (const date of dates) {
+		const { year, week } = getISOWeek(date)
+		const weekKey = bucketKey(year, week)
+		let bucket = buckets.get(weekKey)
+		if (!bucket) {
+			bucket = { year, week, weekKey, dayKeys: [], dates: [] }
+			buckets.set(weekKey, bucket)
+			order.push(weekKey)
+		}
+		bucket.dayKeys.push(getDayKeyOfDate(date))
+		bucket.dates.push(date)
+	}
+	return order.map((k) => buckets.get(k)!)
+}
+
+export function bucketKey(year: number, week: number): string {
+	return `${year}-${week}`
 }

--- a/tests/Controller/PageControllerTest.php
+++ b/tests/Controller/PageControllerTest.php
@@ -6,7 +6,12 @@ namespace OCA\WeekPlanner\Tests\Controller;
 
 use OCA\WeekPlanner\Controller\PageController;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Services\IInitialState;
+use OCP\IConfig;
 use OCP\IRequest;
+use OCP\IUser;
+use OCP\IUserSession;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -14,19 +19,99 @@ use PHPUnit\Framework\TestCase;
  */
 class PageControllerTest extends TestCase {
 	private PageController $controller;
+	private IInitialState&MockObject $initialState;
+	private IConfig&MockObject $config;
+	private IUserSession&MockObject $userSession;
 
 	protected function setUp(): void {
+		$this->initialState = $this->createMock(IInitialState::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->userSession = $this->createMock(IUserSession::class);
 		$this->controller = new PageController(
-			'weekplanner',
 			$this->createMock(IRequest::class),
+			$this->initialState,
+			$this->config,
+			$this->userSession,
 		);
 	}
 
 	public function testIndexReturnsTemplateResponse(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+
 		$response = $this->controller->index();
 
 		self::assertInstanceOf(TemplateResponse::class, $response);
 		self::assertSame('index', $response->getTemplateName());
 		self::assertSame('weekplanner', $response->getApp());
+	}
+
+	public function testIndexInjectsFirstDayOfWeekFromCorePersonalSetting(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+		$this->userSession->method('getUser')->willReturn($user);
+
+		$this->config->method('getUserValue')
+			->willReturnCallback(function (string $uid, string $app, string $key, string $default): string {
+				if ($uid === 'alice' && $app === 'core' && $key === 'first_day_of_week') {
+					return '5'; // Friday
+				}
+				return $default;
+			});
+
+		$this->initialState->expects(self::once())
+			->method('provideInitialState')
+			->with('firstDayOfWeek', 5);
+
+		$this->controller->index();
+	}
+
+	public function testIndexFallsBackToWeekplannerOverride(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+		$this->userSession->method('getUser')->willReturn($user);
+
+		$this->config->method('getUserValue')
+			->willReturnCallback(function (string $uid, string $app, string $key, string $default): string {
+				if ($app === 'weekplanner' && $key === 'firstDayOfWeek') {
+					return '6'; // Saturday
+				}
+				return $default;
+			});
+
+		$this->initialState->expects(self::once())
+			->method('provideInitialState')
+			->with('firstDayOfWeek', 6);
+
+		$this->controller->index();
+	}
+
+	public function testIndexDefaultsToMondayWhenNoUser(): void {
+		$this->userSession->method('getUser')->willReturn(null);
+
+		$this->initialState->expects(self::once())
+			->method('provideInitialState')
+			->with('firstDayOfWeek', 1);
+
+		$this->controller->index();
+	}
+
+	public function testIndexDefaultsToMondayWhenStoredValueIsInvalid(): void {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('alice');
+		$this->userSession->method('getUser')->willReturn($user);
+
+		$this->config->method('getUserValue')
+			->willReturnCallback(function (string $uid, string $app, string $key, string $default): string {
+				if ($app === 'core' && $key === 'first_day_of_week') {
+					return '99'; // out of range
+				}
+				return $default;
+			});
+
+		$this->initialState->expects(self::once())
+			->method('provideInitialState')
+			->with('firstDayOfWeek', 1);
+
+		$this->controller->index();
 	}
 }


### PR DESCRIPTION
The weekly view was hardcoded to ISO Monday-Sunday regardless of the user's "Personal settings > Region & language > First day of week" value. With any other start day the visible window now spans two ISO weeks (e.g. Sunday-start on a Wednesday shows last week's Sunday plus this week's Mon-Sat), so the persistence layer was rebuilt to load and save up to two ISO buckets at once, stitching the visible days from each.

Storage stays Mon-Sun keyed by ISO week, so existing data is untouched. The backend reads from core.first_day_of_week (the actual key Personal settings writes to) and ships it via IInitialState.

The visual layout keeps the previous five-full-columns plus two-stacked shape. The stacked pair just shifts to whichever two days fall at the end of the visible window.